### PR TITLE
fix wrong placement of `deps` in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,8 +17,8 @@ defmodule Edeliver.Mixfile do
           "README.md",
         ],
         links: %{"GitHub" => "https://github.com/boldpoker/edeliver"},
-        deps: deps,
       ],
+      deps: deps,
     ]
   end
 


### PR DESCRIPTION
fixes https://github.com/boldpoker/edeliver/issues/22