### PR TITLE
install hex non-interactive

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -113,6 +113,7 @@ erlang_get_and_update_deps() {
       else
         echo \"rebar for mix was built already\" $SILENCE
       fi
+      $MIX_CMD local.hex --force $SILENCE
       $MIX_CMD deps.get $SILENCE
     fi
   "


### PR DESCRIPTION
deployment fails if hex isn't installed and mix asks for installing hex which requires manual interaction

```sh
vagrant@edeliver-vagrant ~/b/e/ed ❯❯❯ mix deps.get
Could not find hex, which is needed to build dependency :phoenix
Shall I install hex? [Yn]
```