### PR TITLE
Had issues with a exrm/mix build ... this fixed it

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -166,7 +166,7 @@ erlang_generate_release() {
       $RELX_CMD release $SILENCE
     elif [ \"$RELEASE_CMD\" = \"mix\" ]; then
       echo \"using mix to generate release\" $SILENCE
-      MIX_ENV=prod LINK_SYS_CONFIG=\"$LINK_SYS_CONFIG\" LINK_VM_ARGS=\"$LINK_VM_ARGS\" $MIX_CMD release $SILENCE
+      MIX_ENV=prod LINK_SYS_CONFIG=\"$LINK_SYS_CONFIG\" LINK_VM_ARGS=\"$LINK_VM_ARGS\" $MIX_CMD do compile, release $SILENCE
     fi
 
   "

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Edeliver.Mixfile do
   end
 
   defp deps, do: [
-    {:exrm, "~> 0.16.0"},
+    {:exrm, "~> 0.19"},
   ]
 
 end


### PR DESCRIPTION
Hi,

I had issues with a recent elixir build and this fixed it. The problem was that `mix release` did not compile the sources, changing it to `mix do compile, release` fixed it.

```
$ iex
Erlang/OTP 18 [erts-7.0] [source] [64-bit] [async-threads:10] [kernel-poll:false]

Interactive Elixir (1.1.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
```

Hope this helps ...