### PR TITLE
Add Auto-Versioning

### DIFF
--- a/doc/auto-versioning.md
+++ b/doc/auto-versioning.md
@@ -1,10 +1,10 @@
 ### Using Auto-Versioning
 
 edeliver provides a way to automatically __increment__ the current __version__ for the __current build__ and/or to __append__ the __git commit count__ and/or __revision__ as [version metadata](http://semver.org/#spec-item-10).
-__Using a different version for each release is essential__ especially if you build hot code __upgrades__, but also makes sense to see wich version is running, e.g. when using `mix edeliver version [staging|production]`.
+__Using a different versions for each release is essential__ especially if you build hot code __upgrades__, but also makes sense to see wich version is running, e.g. when using `mix edeliver version [staging|production]`.
 
 Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` command line option or the `SKIP_MIX_CLEAN=true` config respectively*.
-For detailed information also try `mix edeliver help upgrade`, `mix edeliver help release` or `mix help release.version`.
+
 
 ##### Append git commit count and/or revision to the release version
 
@@ -28,6 +28,8 @@ For detailed information also try `mix edeliver help upgrade`, `mix edeliver hel
   1.0.0
   mix edeliver build release --auto-version=git-branch
   # creates version 1.0.0+master
+  mix edeliver build release --auto-version=git-revision+git-branch-unless-master
+  # creates version 1.0.0+82a5834
   mix edeliver build upgrade --auto-version=build-date
   # creates version 1.0.0+20160414
   mix edeliver build upgrade --auto-version=git-revision+build-date
@@ -38,10 +40,31 @@ For detailed information also try `mix edeliver help upgrade`, `mix edeliver hel
 
 To append metadata permanentely you can set the `AUTO_VERSION` configuration variable in your `.deliver/config` file. This can be overridden by the `--auto-version=` command line argument.
 
-```
+```sh
  # ./deliver/config
- AUTO_VERSION=commit-count+git-revision
+ AUTO_VERSION=commit-count+git-revision+branch-unless-master
 ```
+
+##### Available metadata which can be appended to the release version
+
+
+  * `[git-]revision` Appends sha1 git revision of current HEAD.
+  * `[git-]branch` Appends the current branch that is built.
+  * `[git-]branch-unless-master` Appends the current branch that is built but only unless it is the master branch.
+  * `[build-]date` Appends the build date as YYYYMMDD.
+  * `[git-]commit-count[-all[-branches]` Appends the number of commits across all branches.
+    Allows edeliver to detect which version is newer if it is appended as first metadata to
+    the release version.
+  * `[git-]commit-count-branch` Appends the number of commits from the current branch.
+    This makes more sense, if the branch name is also appended as metadata to avoid
+    conflicts from different branches.
+
+
+Using __commit count accross all branches__ (`commit-count[-all[-branches]`) __or__ using the __build date__ (`[build-]date`) __as first metadata__ to append, enables edeliver to __consider__ that values __when sorting__ versions. Using `[git-]revision` or commit count for the current branch in conjunction with the branch name (`commit-count-branch+branch`) enables you to __uniquely identify__ the built/deployed __version__. edeliver can then display the commit message for that version (and the 5 previous commit messages) if `edeliver version [staging|production]` is used with the `--verbose` flag. To achieve both (sorting and identifying versions) and to see whether a feature branch is built/deployed, the following permanent auto-versioning option is recommended: `AUTO_VERSION=commit-count+git-revision+branch-unless-master`.
+
+
+For more information also try `mix edeliver help upgrade`, `mix edeliver help release` or `mix help release.version`.
+
 
 
 ##### Increment / Set Version for the current release / upgrade
@@ -64,7 +87,7 @@ To append metadata permanentely you can set the `AUTO_VERSION` configuration var
 
 ##### Use the Auto-Versioning / Increment-Version mix task locally
 
-You can also use the auto versioning mix task provided by edeliver locally on your development machine, e.g. when testing your release / upgrade. The argument names to append metadata differ slightly and contain an `append-` prefix. If version modifiers are combined, they must be separated by a space.
+You can also use the auto versioning mix task provided by edeliver locally on your development machine, e.g. when testing your release / upgrade. The argument names to append metadata differ slightly and contain an (optional) `append-` prefix. If version modifiers are combined, they can be separated by a space (or by the `+` character as for the edeliver option).
 It is required to clean the build output before* and to run the `release.version` and `release` mix tasks together using the `mix do` task while running the `release.version` task before the `release` task.
 
 ```sh

--- a/doc/auto-versioning.md
+++ b/doc/auto-versioning.md
@@ -59,6 +59,7 @@ To append metadata permanentely you can set the `AUTO_VERSION` configuration var
 
 ```
 
+`--increment-version=` and `--set-version=` can be used in conjunction with the `--auto-version=` option. The `AUTO_VERSION` default is also used unless the `--auto-version=` overrides it.
 
 ##### Use the Auto-Versioning / Increment-Version mix task locally
 
@@ -67,10 +68,17 @@ It is required to clean the build output before* and to run the `release.version
 
 ```sh
   mix release.version show
+  1.2.3
+  mix do clean, release.version increase major revision branch --dry-run
+  Would update version from 1.2.3 to 2.0.0+82a5834-test
+  # prints only the info above. You can always ommit the 'append-git-' part.
   mix do clean, release.version append-git-revision, release
-  mix do clean, release.version append-commit-count append-git-revision, release
+  # creates version 1.2.3+82a5834
+  mix do clean, release.version append-commit-count append-git-revision append-git-branch, release
+  # creates version 1.2.3+3027-82a5834-master
   mix do clean, release.version increase major, release
-  mix do clean, release.version set 1.3.0-beta.1, release
+  AUTO_VERSION="append-git-revision" mix do clean, release.version set 1.3.0-beta.1, release
+  # creates version 1.3.0-beta.1+82a5834
 ```
 
 (*) The build files must be removed to ensure that the `your_app.app` file will be (re-)generated with the new version.

--- a/doc/auto-versioning.md
+++ b/doc/auto-versioning.md
@@ -1,0 +1,76 @@
+### Using Auto-Versioning
+
+edeliver provides a way to automatically __increment__ the current __version__ for the __current build__ or to __append__ the __git commit count__ and/or __revision__ as [version metadata](http://semver.org/#spec-item-10).
+__Using a different version for each release is essential__ especially if you build hot code __upgrades__, but also makes sense to see wich version is running, e.g. when using `mix edeliver version [staging|production]`.
+
+Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` command line option or the `SKIP_MIX_CLEAN=true` config respectively*.
+
+##### Append git commit count and/or revision to the release version
+
+```sh
+  mix release.version show
+  1.0.0
+  mix edeliver build release --auto-version=commit-count
+  # creates version 1.0.0+3027
+  mix edeliver build upgrade --auto-version=git-revision
+  # creates version 1.0.0+82a5834
+  mix edeliver build upgrade --auto-version=commit-count+git-revision
+  # creates version 1.0.0+3027-82a5834
+  mix edeliver build upgrade --auto-version=git-revision+commit-count
+  # creates version 1.0.0+82a5834-3027
+```
+
+##### Append other metadata: git branch or build date
+
+```sh
+  mix release.version show
+  1.0.0
+  mix edeliver build release --auto-version=git-branch
+  # creates version 1.0.0+master
+  mix edeliver build upgrade --auto-version=build-date
+  # creates version 1.0.0+2016.04.14
+  mix edeliver build upgrade --auto-version=git-revision+build-date
+  # creates version 1.0.0+82a5834-2016.04.14
+```
+
+##### Append metadata to version permanentely
+
+To append metadata permanentely you can set the `AUTO_VERSION` configuration variable in your `.deliver/config` file. This can be overridden by the `--auto-version=` command line argument.
+
+```
+ # ./deliver/config
+ AUTO_VERSION=commit-count+git-revision
+```
+
+
+##### Increment / Set Version for the current release / upgrade
+
+```sh
+  mix release.version show
+  1.2.3
+  mix edeliver build release --increment-version=patch
+  # creates version 1.2.4
+  mix edeliver build release --increment-version=minor
+  # creates version 1.3.0
+  mix edeliver build release --increment-version=minor
+  # creates version 2.0.0
+  mix edeliver build release --set-version=1.3.0-beta.1
+  # creates version 1.3.0-beta.1
+
+```
+
+
+##### Use the Auto-Versioning / Increment-Version mix task locally
+
+You can also use the auto versioning mix task provided by edeliver locally on your development machine, e.g. when testing your release / upgrade. The argument names to append metadata differ slightly and contain an `append-` prefix. If version modifiers are combined, they must be separated by a space.
+It is required to clean the build output before* and to run the `release.version` and `release` mix tasks together using the `mix do` task while running the `release.version` task before the `release` task.
+
+```sh
+  mix release.version show
+  mix do clean, release.version append-git-revision, release
+  mix do clean, release.version append-commit-count append-git-revision, release
+  mix do clean, release.version increase major, release
+  mix do clean, release.version set 1.3.0-beta.1, release
+```
+
+(*) The build files must be removed to ensure that the `your_app.app` file will be (re-)generated with the new version.

--- a/doc/auto-versioning.md
+++ b/doc/auto-versioning.md
@@ -1,9 +1,10 @@
 ### Using Auto-Versioning
 
-edeliver provides a way to automatically __increment__ the current __version__ for the __current build__ or to __append__ the __git commit count__ and/or __revision__ as [version metadata](http://semver.org/#spec-item-10).
+edeliver provides a way to automatically __increment__ the current __version__ for the __current build__ and/or to __append__ the __git commit count__ and/or __revision__ as [version metadata](http://semver.org/#spec-item-10).
 __Using a different version for each release is essential__ especially if you build hot code __upgrades__, but also makes sense to see wich version is running, e.g. when using `mix edeliver version [staging|production]`.
 
 Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` command line option or the `SKIP_MIX_CLEAN=true` config respectively*.
+For detailed information also try `mix edeliver help upgrade`, `mix edeliver help release` or `mix help release.version`.
 
 ##### Append git commit count and/or revision to the release version
 

--- a/doc/auto-versioning.md
+++ b/doc/auto-versioning.md
@@ -28,9 +28,9 @@ Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` c
   mix edeliver build release --auto-version=git-branch
   # creates version 1.0.0+master
   mix edeliver build upgrade --auto-version=build-date
-  # creates version 1.0.0+2016.04.14
+  # creates version 1.0.0+20160414
   mix edeliver build upgrade --auto-version=git-revision+build-date
-  # creates version 1.0.0+82a5834-2016.04.14
+  # creates version 1.0.0+82a5834-20160414
 ```
 
 ##### Append metadata to version permanentely

--- a/doc/auto-versioning.md
+++ b/doc/auto-versioning.md
@@ -60,12 +60,58 @@ To append metadata permanentely you can set the `AUTO_VERSION` configuration var
     conflicts from different branches.
 
 
-Using __commit count accross all branches__ (`commit-count[-all[-branches]`) __or__ using the __build date__ (`[build-]date`) __as first metadata__ to append, enables edeliver to __consider__ that values __when sorting__ versions. Using `[git-]revision` or commit count for the current branch in conjunction with the branch name (`commit-count-branch+branch`) enables you to __uniquely identify__ the built/deployed __version__. edeliver can then display the commit message for that version (and the 5 previous commit messages) if `edeliver version [staging|production]` is used with the `--verbose` flag. To achieve both (sorting and identifying versions) and to see whether a feature branch is built/deployed, the following permanent auto-versioning option is recommended: `AUTO_VERSION=commit-count+git-revision+branch-unless-master`.
+Using __commit count accross all branches__ (`commit-count[-all[-branches]`) __or__ using the __build date__ (`[build-]date`) __as first metadata__ to append, enables edeliver to __consider__ that values __when sorting__ versions. Using `[git-]revision` or commit count for the current branch in conjunction with the branch name (`commit-count-branch+branch`) enables you to __uniquely identify__ the built/deployed __version__. If the revision is used, __edeliver can display the commit message for that version__ (and the 5 previous commit messages) if `edeliver version [staging|production]` is used. To achieve both (sorting and identifying versions) and to see whether a feature branch is built/deployed, the following permanent auto-versioning option is recommended: `AUTO_VERSION=commit-count+git-revision+branch-unless-master`.
 
 
 For more information also try `mix edeliver help upgrade`, `mix edeliver help release` or `mix help release.version`.
 
+Example Output for `edeliver version` task if `git-revision` is used for auto-versioning:
 
+```sh
+$ mix edeliver version production
+
+EDELIVER YOUR_APP WITH VERSION COMMAND
+
+-----> getting release versions from production servers
+
+production node: 0
+
+  user    : production
+  host    : host-01.domain.net
+  path    : /your/deploy/path
+  response: 1.2.3+4915-e834c67
+  branch  : master
+  revision: e834c67
+  date    : 2016-04-19 17:10:13 (git commit)
+  commits : Use autoversion for edeliver
+            Update release version to 1.2.3
+            Revert something
+            Add something
+            ...
+
+
+production node: 1
+
+  user    : production
+  host    : host-12.domain.net
+  path    : /your/deploy/path
+  response: 1.2.3+4931-4805b65
+  branch  : feature
+  revision: 4805b65
+  date    : 2016-04-21 16:41:01 (git commit)
+  commits : Add another feature
+            Add new feature
+            Use autoversion for edeliver
+            Update release version to 1.2.3
+            Revert something
+            Add something
+            ...
+
+
+VERSION DONE!
+```
+
+Then number of commits can be adjusted by the `VERSION_INFO_LAST_COMMITS` env / config.
 
 ##### Increment / Set Version for the current release / upgrade
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,0 +1,60 @@
+# Configuration (.deliver/config)
+
+
+### Required Configuration
+
+This options can or must be set in the `.deliver/config` file to configure edeliver:
+
+| environment variable   | required | info                                           |
+|------------------------|----------|------------------------------------------------|
+| `APP`                  |      yes | the lower case name of your app                |
+| `BUILD_AT`             |      yes | the directory on the build host to build at    |
+| `BUILD_CMD`            |       no | tool used to build sources. (mix|rebar)        |
+| `BUILD_HOST`           |      yes | the host to build at                           |
+| `BUILD_USER`           |      yes | the ssh user for the host to build at          |
+| `DELIVER_TO`           |      yes | the directory on production hosts to deploy to |
+| `GIT_CLEAN_PATHS`      |       no | don't clean everything when building           |
+| `PRODUCTION_HOSTS`     |      yes | the production hosts to deploy to              |
+| `PRODUCTION_USER`      |      yes | the ssh user for the production hosts          |
+| `RELEASE_CMD`          |       no | tool used to build release. (mix|relx|rebar)   |
+| `STAGING_HOSTS`        |       no | the staging hosts to deploy to                 |
+| `STAGING_USER`         |       no | the ssh user for the staging hosts             |
+| `TEST_AT`              |       no | the directory on staging hosts to deploy to    |
+
+See also [Configuration Section](https://github.com/boldpoker/edeliver#user-content-configuration) in the [README](https://github.com/boldpoker/edeliver/blob/master/README.md).
+
+### Use edeliver Options Permanentely
+
+This options can be set in the `.deliver/config` file to use the command line option permanentely without passing them every time:
+
+
+| environment variable in config file   | edeliver argument    | info                                          |
+|---------------------------------------|----------------------|-----------------------------------------------|
+| `AUTO_VERSION=...`                    | `--auto-version=...` | append metadata to version                    |
+| `CLEAN_DEPLOY=boolean`                | `--clean-deploy`     | remove data from old releases                 |
+| `FORCE=boolean`                       | `--force`            | don't ask                                     |
+| `RELUP_MODIFICATION_MODULE=...`       | `--relup-mod=...`    | specify module to modify relups automatically |
+| `SKIP_GIT_CLEAN=boolean`              | `--skip-git-clean`   | don't clean anything when building            |
+| `SKIP_MIX_CLEAN=boolean`              | `--skip-mix-clean`   | don't clean compiled output when building     |
+| `SKIP_RELUP_MODIFICATIONS=boolean`    | `--skip-relup-mod`   | don't modify relup automaticaly               |
+| `START_DEPLOY=boolean`                | `--start-deploy`     | (re-) start node(s) after deploy              |
+| `TARGET_MIX_ENV=prod|dev|...`         | `--mix-env=...`      | build with custom `MIX_ENV`                   |
+
+Passing any of that arguements to edeliver overrides the value set in the config file.
+Try also `edeliver help build release`, `edeliver help build upgrade` or `edeliver help deploy release` for more information.
+
+### Additional Envirionment Variables available in config file
+
+
+This environment variables are set by edeliver and can be used `.deliver/config` file to adjust something:
+
+
+| environment variable  | possible values         |
+|-----------------------|-------------------------|
+| `$MODE`               | `verbose|compact|debug` |
+| `$VERBOSE`            | `true|false`            |
+| `$SILENCE`            | `true|false`            |
+| `$DEPLOY_ENVIRONMENT` | `staging|production`    |
+| `$NODE_ENVIRONMENT`   | `staging|production`    |
+
+See also [Extend edeliver (config) to fit your needs](https://github.com/boldpoker/edeliver/wiki/Extend-edeliver-(config)-to-fit-your-needs) to see some use cases.

--- a/lib/mix/tasks/edeliver.ex
+++ b/lib/mix/tasks/edeliver.ex
@@ -53,7 +53,9 @@ defmodule Mix.Tasks.Edeliver do
     * `--skip-mix-clean` Skip the 'mix clean step' for faster builds. Makes only sense in addition to the --skip-git-clean
     * `--skip-relup-mod`  Skip modification of relup file. Custom relup instructions are not added
     * `--relup-mod=<module-name>` The name of the module to modify the relup
-    * `--auto-version=[patch|minor|major|git]` Automatically increases the patch, minor or major version or appends the git sha1 revision to the current version
+    * `--auto-version=revision|commit-count|branch|date` Automatically append metadata to release version.
+    * `--increment-version=major|minor|patch` Increase the version for the current build.
+    * `--set-version=<release-version>` Set the release version for the current build.
     * `--mix-env=<env>` Build with custom mix env $MIX_ENV. Default is 'prod'
 
   """

--- a/lib/mix/tasks/edeliver.ex
+++ b/lib/mix/tasks/edeliver.ex
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Edeliver do
     * `--skip-relup-mod`  Skip modification of relup file. Custom relup instructions are not added
     * `--relup-mod=<module-name>` The name of the module to modify the relup
     * `--auto-version=revision|commit-count|branch|date` Automatically append metadata to release version.
-    * `--increment-version=major|minor|patch` Increase the version for the current build.
+    * `--increment-version=major|minor|patch` Increment the version for the current build.
     * `--set-version=<release-version>` Set the release version for the current build.
     * `--mix-env=<env>` Build with custom mix env $MIX_ENV. Default is 'prod'
 

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -285,7 +285,11 @@ defmodule Mix.Tasks.Release.Version do
   @doc "Gets the current branch that will be built"
   @spec get_branch() :: String.t
   def get_branch() do
-    System.cmd( "git", ["rev-parse", "--abbrev-ref", "HEAD"]) |> elem(0) |> String.rstrip
+    System.cmd( "git", ["rev-parse", "--abbrev-ref", "HEAD"]) |> elem(0) |> String.rstrip |> valid_semver_metadata()
+  end
+
+  def valid_semver_metadata(string) do
+    IO.chardata_to_string(for <<c <- string>>, (c >= ?a and c <= ?z) or (c >= ?A and c <= ?Z) or (c >= ?0 and c <= ?9) or c == ?-, do: c)
   end
 
   @doc "Gets the current date in the form yyyymmdd"

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -173,9 +173,13 @@ defmodule Mix.Tasks.Release.Version do
       end
     end) |> Enum.map(fn(arg) ->
       case arg do
-        "commit-count" -> "commit_count"
         "git-" <> command -> command
         "build-" <> command -> command
+        command -> command
+      end
+    end) |> Enum.map(fn(arg) ->
+      case arg do
+        "commit-count" -> "commit_count"
         command -> command
       end
     end)

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -196,7 +196,7 @@ defmodule Mix.Tasks.Release.Version do
   def normalize_args(args) do
     args |> List.foldr([], fn(arg, acc) ->
       if String.contains?(arg, "+") do
-        String.split(arg, "+") ++ acc
+        String.split(arg, "+", trim: true) ++ acc
       else
         [arg | acc]
       end

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -167,12 +167,13 @@ defmodule Mix.Tasks.Release.Version do
     illegal_combinations = Enum.filter args, &(Enum.member?(update_version_options, &1))
     cond do
       args == ["show"] -> :show
-      unknown_options == ["count"] -> {:error, "Unknown option 'count'.\nDid you mean 'commit-count'?"}
-      Enum.count(unknown_options) > 0 -> {:error, "Unknown options: #{Enum.join(unknown_options, " ")}"}
-      args == [] -> {:error, "No arguments passed and no AUTO_VERSION env is set."}
-      Enum.count(illegal_combinations) > 1 -> {:error, "Illegal combination of options: #{Enum.join(illegal_combinations, " ")} can't be used together."}
-      Enum.member?(args, "set") && (version_to_set == nil || Enum.member?(known_options, version_to_set)) -> {:error, "No version to set. Please add the version as argument after 'set' like: 'set 2.0.0-beta'."}
-      Enum.any?(default_args, &(Enum.member?(illegal_combinations, &1))) ->  {:error, "Increasing major|minor|path or setting version is not allowed as default set in 'AUTO_VERSION' env."}
+      unknown_options == ["count"] -> {:error, "Unknown option 'count' for 'release.version' task.\nDid you mean 'commit-count'?"}
+      Enum.count(unknown_options) == 1 -> {:error, "Unknown option #{Enum.join(unknown_options, " ")} for 'release.version' task."}
+      Enum.count(unknown_options) > 1 -> {:error, "Unknown options for 'release.version' task: #{Enum.join(unknown_options, " ")}"}
+      args == [] -> {:error, "No arguments passed to 'release.version' task and no AUTO_VERSION env is set."}
+      Enum.count(illegal_combinations) > 1 -> {:error, "Illegal combination of options for 'release.version' task: #{Enum.join(illegal_combinations, " ")} can't be used together."}
+      Enum.member?(args, "set") && (version_to_set == nil || Enum.member?(known_options, version_to_set)) -> {:error, "No version to set for 'release.version' task. Please add the version as argument after 'set' like: 'set 2.0.0-beta'."}
+      Enum.any?(default_args, &(Enum.member?(illegal_combinations, &1))) ->  {:error, "Increasing major|minor|path or setting version is not allowed as default set in 'AUTO_VERSION' env for 'release.version' task."}
       true ->
         modification_functions = Enum.map args, fn(arg) ->
           case arg do

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -24,9 +24,10 @@ defmodule Mix.Tasks.Release.Version do
   ## Append-Metadata
 
     * `[append-][git-]revision` Appends sha1 git revision of current HEAD
-    * `[append-][git-]branch` Appends the current branch that is built
+    * `[append-][git-]branch[-unless-master]` Appends the current branch that is built. If
+      `-unless-master` is used, the branch is only appended unless it is the master branch.
     * `[append-][build-]date` Appends the build date as YYYYMMDD
-    * `[append-][git-]commit-count[-all[-branches]|-branch|]` Appends the number of commits
+    * `[append-][git-]commit-count[-all[-branches]|-branch]` Appends the number of commits
       from the current branch or across all branches (default).  Appending the commit count
       from the current branch makes more sense, if the branch name is also appended as metadata
       to avoid conflicts from different branches.
@@ -153,7 +154,7 @@ defmodule Mix.Tasks.Release.Version do
   """
   @spec parse_args(OptionParser.argv) :: :show | {:error, message::String.t} | {:modify, [modification_fun]}
   def parse_args(args) do
-    append_metadata_options = ["commit_count", "commit_count_branch", "revision", "date", "branch"]
+    append_metadata_options = ["commit_count", "commit_count_branch", "revision", "date", "branch", "branch_unless_master"]
     update_version_options  = ["major", "minor", "patch", "set"]
 
     args = normalize_args(args)
@@ -227,6 +228,7 @@ defmodule Mix.Tasks.Release.Version do
       case arg do
         "commit-count" -> "commit_count"
         "commit-count-branch" -> "commit_count_branch"
+        "branch-unless-master" -> "branch_unless_master"
         command -> command
       end
     end)
@@ -262,6 +264,13 @@ defmodule Mix.Tasks.Release.Version do
   def modify_version_revision({version, has_metadata}),            do: {add_metadata(version, __MODULE__.get_git_revision, has_metadata),        _has_metadata = true}
   def modify_version_date({version, has_metadata}),                do: {add_metadata(version, __MODULE__.get_date, has_metadata),                _has_metadata = true}
   def modify_version_branch({version, has_metadata}),              do: {add_metadata(version, __MODULE__.get_branch, has_metadata),              _has_metadata = true}
+  def modify_version_branch_unless_master({version, has_metadata}) do
+    case __MODULE__.get_branch do
+      "master"     -> {version, has_metadata}
+      other_branch -> {add_metadata(version, other_branch, has_metadata), _has_metadata = true}
+    end
+  end
+
 
   def modify_version_set({_version, has_metadata}, version_to_set), do: {version_to_set, has_metadata}
 

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -6,18 +6,28 @@ defmodule Mix.Tasks.Release.Version do
   @moduledoc """
   Displays the release version or modifies it before building the release.
   This task can be used in conjunction with the `release` task to modify
-  the version for the release / upgrade.
+  the version for the release / upgrade. The compiled files must be cleaned
+  before and the release task must be executed after. Increasing version
+  and appending metadata to the version can be combined, e.g:
+
+  `mix do clean, release.version increase minor append-git-revision append-branch, release`
+
+  To automatically append metadata, you can set the `$AUTO_VERSION` environment variable.
 
   # Usage:
 
     * mix release.version [show]
-    * mix release.version set <new-version> [Option]
-    * mix release.version increase [patch|minor|major] [version] [Option]
-    * mix release.version append-git-revision [Option]
+    * mix do clean, release.version set <new-version> [Option], release
+    * mix do clean, release.version increase [patch|minor|major] [version] [Option], release
+    * mix do clean, release.version [append-][git-]revision|commit-count|branch [Option], release
+    * mix do clean, release.version [append-][build-]date [Option], release
 
   ## Actions
     * `show` Displays the current release version.
-    * `append-git-revision` Append sha1 git revision of current HEAD
+    * `append-git-revision` Appends sha1 git revision of current HEAD
+    * `append-git-commit-count` Appends the number of commits across all branches
+    * `append-git-branch` Appends the current branch that is built
+    * `append-build-date` Appends the build date as YYYY.MM.DD
     * `increase` Increases the release version
       - `patch` Increases the patch version (default). The last part of a tripartite version.
       - `minor` Increases the minor version. The middle part of a tripartite version.
@@ -25,7 +35,7 @@ defmodule Mix.Tasks.Release.Version do
 
   ## Options
     * `-V`, `--verbose` Verbose output
-    * `-Q`, `--quiet` Print errors only while modifying version
+    * `-Q`, `--quiet` Print only errors while modifying version
 
 
   ## Example
@@ -132,5 +142,103 @@ defmodule Mix.Tasks.Release.Version do
       Enum.member?(options, "minor") -> :minor
       true -> :patch
     end
+  end
+
+  @type modification_arg :: {modified_version::String.t, has_metadata::boolean}
+  @type modification_fun :: ((modification_arg) -> modification_arg)
+
+  @spec parse_args(OptionParser.argv) :: :show | {:error, message::String.t} | {:modify, [modification_fun]}
+  def parse_args(args) do
+    args = args |> List.foldr([], fn(arg, acc) ->
+      if String.contains?(arg, "+") do
+        String.split(arg, "+") ++ acc
+      else
+        [arg | acc]
+      end
+    end) |> Enum.filter(&(&1 != "increase" && &1 != "version"))
+    args = args |> Enum.map(fn(arg) ->
+      case arg do
+        "append-" <> command -> command
+        command -> command
+      end
+    end) |> Enum.map(fn(arg) ->
+      case arg do
+        "commit-count" -> "commit_count"
+        "git-" <> command -> command
+        "build-" <> command -> command
+        command -> command
+      end
+    end)
+    known_options = ["major", "minor", "patch", "commit_count", "revision", "date", "branch", "set"]
+    unknown_options = args -- known_options
+    illegal_combinations = Enum.filter args, &(Enum.member?(["major", "minor", "patch", "set"], &1))
+    cond do
+      args == ["show"] -> :show
+      unknown_options == ["count"] -> {:error, "Unknown option 'count'.\nDid you mean 'commit-count'?"}
+      Enum.count(unknown_options) > 0 -> {:error, "Unknown options: #{Enum.join(unknown_options, " ")}"}
+      args == [] -> :show
+      Enum.count(illegal_combinations) > 1 -> {:error, "Illegal combination of options: #{Enum.join(illegal_combinations, " ")} can't be used together."}
+      true -> {:modify, Enum.map(args, &(String.to_atom("modify_version_" <> &1)))}
+    end
+  end
+
+  def modify_version_major({version, has_metadata}), do: {update_version(version, :major), has_metadata}
+  def modify_version_minor({version, has_metadata}), do: {update_version(version, :minor), has_metadata}
+  def modify_version_patch({version, has_metadata}), do: {update_version(version, :patch), has_metadata}
+  def modify_version_commit_count({version, has_metadata}), do: {add_metadata(version, __MODULE__.get_commit_count, has_metadata), _has_metadata = true}
+  def modify_version_revision({version, has_metadata}), do:     {add_metadata(version, __MODULE__.get_git_revision, has_metadata), _has_metadata = true}
+  def modify_version_date({version, has_metadata}), do:         {add_metadata(version, __MODULE__.get_date, has_metadata),         _has_metadata = true}
+  def modify_version_branch({version, has_metadata}), do:       {add_metadata(version, __MODULE__.get_branch, has_metadata),       _has_metadata = true}
+
+
+  defp add_metadata(version, metadata, _had_metadata = false), do: version <> "+" <> metadata
+  defp add_metadata(version, metadata, _had_metadata = true),  do: version <> "-" <> metadata
+
+  @doc """
+    Modifies the current release version by applying the `modification_fun`s which
+    were collected while parsing the args. If there was an error parsing the arguments
+    passed to this task, this function prints the error and exists the erlang vm, meaning
+    aborting the mix task. If `:show` is returned from parsing the arguments, this function
+    just prints the current release version.
+  """
+  @spec modify_version({:modify, [modification_fun]} | {:error, message::String.t} | :show, version::String.t) :: :ok | :error | {:modified, new_version::String.t}
+  def modify_version(:show, version) do
+    IO.puts version
+  end
+  def modify_version({:error, message}, version) do
+    IO.puts :stderr, IO.ANSI.red <> "Error: " <> message <> IO.ANSI.reset
+    :error
+  end
+  def modify_version({:modify, modification_functions}, version) do
+    {version, _} = Enum.reduce modification_functions, {version, false}, &(apply(__MODULE__,&1, [&2]))
+    {:modified, version}
+  end
+
+
+  @doc """
+    Gets the current revision of the git repository edeliver is used as deploy tool for.
+    The sha1 hash containing 7 hexadecimal characters is returned.
+  """
+  @spec get_git_revision() :: String.t
+  def get_git_revision() do
+    ""
+  end
+
+  @doc "Gets the current number of commits across all branches"
+  @spec get_commit_count() :: String.t
+  def get_commit_count() do
+    "" # git rev-list --all --count
+  end
+
+  @doc "Gets the current branch that will be built"
+  @spec get_branch() :: String.t
+  def get_branch() do
+
+  end
+
+
+  @spec get_date :: String.t
+  def get_date() do
+
   end
 end

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Release.Version do
   before and the release task must be executed after. Increasing version
   and appending metadata to the version can be combined, e.g:
 
-  `mix do clean, release.version increase minor append-git-revision append-branch, release`
+  `mix do clean, release.version increment minor append-git-revision append-branch, release`
 
   To automatically append metadata, you can set the `$AUTO_VERSION` environment variable.
 
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Release.Version do
 
     * mix release.version show
     * mix do clean, release.version set <new-version> [Option], release
-    * mix do clean, release.version increase [patch|minor|major] [version] [Option], release
+    * mix do clean, release.version increment [patch|minor|major] [version] [Option], release
     * mix do clean, release.version [append-][git-]revision|commit-count|branch [Option], release
     * mix do clean, release.version [append-][build-]date [Option], release
 
@@ -28,10 +28,10 @@ defmodule Mix.Tasks.Release.Version do
     * `append-git-commit-count` Appends the number of commits across all branches
     * `append-git-branch` Appends the current branch that is built
     * `append-build-date` Appends the build date as YYYYMMDD
-    * `increase` Increases the release version
-      - `patch` Increases the patch version (default). The last part of a tripartite version.
-      - `minor` Increases the minor version. The middle part of a tripartite version.
-      - `major` Increases the major version. The first part of a tripartite version.
+    * `increment` Increments the release version
+      - `patch` Increments the patch version (default). The last part of a tripartite version.
+      - `minor` Increments the minor version. The middle part of a tripartite version.
+      - `major` Increments the major version. The first part of a tripartite version.
 
   ## Options
     * `-V`, `--verbose` Verbose output
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Release.Version do
   ## Environment Variables
 
     * `AUTO_VERSION` as long nor arguments are passed directly which append metadata to the version
-                     (`[append-][git-]revision|commit-count|branch|build-data) the values from that
+                     (`[append-][git-]revision|commit-count|branch|build-data`) the values from that
                      env are used to append metadata.
 
   ## Example
@@ -201,7 +201,7 @@ defmodule Mix.Tasks.Release.Version do
         [arg | acc]
       end
     end)
-    |> Enum.filter(&(&1 != "increase" && &1 != "version"))
+    |> Enum.filter(&(&1 != "increment" && &1 != "version"))
     |> Enum.map(fn(arg) ->
       case arg do
         "append-" <> command -> command

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -131,6 +131,19 @@ erlang_get_and_update_deps() {
   __exec_if_defined "post_erlang_get_and_update_deps"
 }
 
+# joins the arguments by the first argument
+__join_string() {
+  local IFS="$1"
+  shift
+  echo "$@" | xargs # xargs removes the whitespaces at the beginning and at the end
+}
+
+# gets the arguments from the --auto-version=, --increment-version and --set-version
+# options and concatenates them ready to be used as arguments for the release.version
+# mis tasks
+__get_auto_version_args() {
+  __join_string " " "$INCREMENT_RELEASE_VERSION" "$SET_RELEASE_VERSION" "$AUTO_RELEASE_VERSION"
+}
 
 # compiles the sources on the remote build host
 erlang_clean_compile() {
@@ -141,12 +154,9 @@ erlang_clean_compile() {
 
   if [ "$RELEASE_CMD" = "mix" ]; then
     [[ "$MODE" = "verbose" ]] && local _auto_release_verbose="--verbose"
-    if [[ "$AUTO_RELEASE_VERSION" =~  ^(patch|minor|major)$ ]]; then
-      local _set_auto_version=" release.version increase $AUTO_RELEASE_VERSION $_auto_release_verbose,"
-    elif [[ "$AUTO_RELEASE_VERSION" == "git" ]]; then
-      local _set_auto_version=" release.version append-git-revision $_auto_release_verbose,"
-    elif [[ -n "$AUTO_RELEASE_VERSION" ]]; then
-      local _set_auto_version=" release.version set \"$AUTO_RELEASE_VERSION\" $_auto_release_verbose,"
+    local _auto_version_args="$(__get_auto_version_args)"
+    if [[ -n "$_auto_version_args" ]] || [[ -n "$AUTO_VERSION" ]]; then
+      local _set_auto_version=" release.version $_auto_version_args $_auto_release_verbose,"
     fi
   fi
   __sync_remote "
@@ -157,15 +167,18 @@ erlang_clean_compile() {
       echo \"using rebar to compile files\"
       [[ \"$SKIP_MIX_CLEAN\" != \"true\" ]] && $REBAR_CMD clean skip_deps=true || :
       $REBAR_CMD compile
-
     elif [ \"$BUILD_CMD\" = \"mix\" ] && [ \"$RELEASE_CMD\" = \"mix\" ]; then
-      [[ \"$SKIP_MIX_CLEAN\" = \"true\" ]] && APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD do${_set_auto_version} compile || APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD do clean,${_set_auto_version} compile
+      if [[ \"$SKIP_MIX_CLEAN\" = \"true\" ]]; then
+        APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" AUTO_VERSION=\"$AUTO_VERSION\" $MIX_CMD do${_set_auto_version} compile
+      else
+        APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" AUTO_VERSION=\"$AUTO_VERSION\" $MIX_CMD do clean,${_set_auto_version} compile
+      fi
     elif [ \"$BUILD_CMD\" = \"mix\" ]; then
       echo \"using mix to compile files\"
       if [[ \"$SKIP_MIX_CLEAN\" = \"true\" ]]; then
-        APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD do deps.compile,${_set_auto_version} compile
+        APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" AUTO_VERSION=\"$AUTO_VERSION\" $MIX_CMD do deps.compile,${_set_auto_version} compile
       else
-        APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD do clean, deps.compile,${_set_auto_version} compile
+        APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" AUTO_VERSION=\"$AUTO_VERSION\" $MIX_CMD do clean, deps.compile,${_set_auto_version} compile
       fi
     fi
   "
@@ -191,12 +204,9 @@ erlang_generate_release() {
     # until the release task fails and then it might be helpful to see the very very verbose output.
     [[ "$MODE" = "verbose" ]] && local _mix_release_verbosity="normal" || local _mix_release_verbosity="verbose"
     [[ "$MODE" = "verbose" ]] && local _auto_release_verbose="--verbose"
-    if [[ "$AUTO_RELEASE_VERSION" =~  ^(patch|minor|major)$ ]]; then
-      local _set_auto_version="do release.version increase $AUTO_RELEASE_VERSION $_auto_release_verbose, "
-    elif [[ "$AUTO_RELEASE_VERSION" == "git" ]]; then
-      local _set_auto_version="do release.version append-git-revision $_auto_release_verbose, "
-    elif [[ -n "$AUTO_RELEASE_VERSION" ]]; then
-      local _set_auto_version="do release.version set \"$AUTO_RELEASE_VERSION\" $_auto_release_verbose, "
+    local _auto_version_args="$(__get_auto_version_args)"
+    if [[ -n "$_auto_version_args" ]] || [[ -n "$AUTO_VERSION" ]]; then
+      local _set_auto_version="do release.version $_auto_version_args $_auto_release_verbose, "
     fi
   fi
 
@@ -213,9 +223,8 @@ erlang_generate_release() {
       $RELX_CMD release
     elif [ \"$RELEASE_CMD\" = \"mix\" ]; then
       echo \"using mix to generate release\"
-      MIX_ENV=\"$TARGET_MIX_ENV\" LINK_SYS_CONFIG=\"$LINK_SYS_CONFIG\" LINK_VM_ARGS=\"$LINK_VM_ARGS\" APP=\"$APP\" $MIX_CMD $_set_auto_version release $_force_no_interaction --verbosity=$_mix_release_verbosity
+      MIX_ENV=\"$TARGET_MIX_ENV\" LINK_SYS_CONFIG=\"$LINK_SYS_CONFIG\" LINK_VM_ARGS=\"$LINK_VM_ARGS\" APP=\"$APP\" AUTO_VERSION=\"$AUTO_VERSION\" $MIX_CMD $_set_auto_version release $_force_no_interaction --verbosity=$_mix_release_verbosity
     fi
-
   "
 
   __exec_if_defined "post_erlang_generate_release"
@@ -1037,10 +1046,10 @@ __detect_remote_release_version() {
 __show_upgrade_version_does_not_differ_error_message() {
     error_message "The build upgrade has the same version as the installed version."
     error_message "That release cannot be deployed as an upgrade. Alter the release version"
-    error_message "or consider using the --auto-version=[git|patch|minor|major] option"
+    error_message "or consider using the --auto-version=revision|commit-count|date option"
     error_message "to automatically increase the version or append the git revision."
     error_message "It is recommended to enable the git-auto-revision permanently"
-    error_message "for automatic upgrades by setting AUTO_RELEASE_VERSION=git in the config."
+    error_message "for automatic upgrades by setting AUTO_VERSION=revision in the config."
 }
 
 __detect_exrm_version() {

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1047,7 +1047,7 @@ __show_upgrade_version_does_not_differ_error_message() {
     error_message "The build upgrade has the same version as the installed version."
     error_message "That release cannot be deployed as an upgrade. Alter the release version"
     error_message "or consider using the --auto-version=revision|commit-count|date option"
-    error_message "to automatically increase the version or append the git revision."
+    error_message "to automatically increment the version or append the git revision."
     error_message "It is recommended to enable the git-auto-revision permanently"
     error_message "for automatic upgrades by setting AUTO_VERSION=revision in the config."
 }

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -50,7 +50,7 @@ __help() {
       --skip-relup-mod  Skip modification of relup file. Custom relup instructions are not added
       --relup-mod=<module-name> The name of the module to modify the relup
       --auto-version=revision|commit-count|branch|date Automatically append metadata to release version.
-      --increment-version=major|minor|patch Increase the version for the current build.
+      --increment-version=major|minor|patch Increment the version for the current build.
       --set-version=<release-version> Set the release version for the current build.
       --start-deploy    Starts the deployed release. If release is running, it is restarted!
       --host=[u@]vwx.yz Run command only on that host, even if different hosts are configured

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -407,7 +407,7 @@ do
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#append-*}
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#git-*}
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#build-*}
-          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|commit-count-branch|commit-count-all|commit-count-all-branches|branch|date)$ ]]; then
+          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|commit-count-branch|commit-count-all|commit-count-all-branches|branch|branch-unless-master|date)$ ]]; then
             __help; error_message "Illegal value for --auto-version= option: '${ORIGINAL_AUTO_VERSION_ARG}'.\n"; exit 2
           fi
         done

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -94,6 +94,9 @@ if (( $# )); then
           (appups|appup)
             COMMAND_INFO="appup"
           ;;
+          (-*)
+            __help; error_message "No build type found. Use release|upgrade\n"; exit 2
+          ;;
           (*)
             __help; error_message "Unknown build type ${arg}. Use release|upgrade\n"; exit 2
           ;;
@@ -109,6 +112,9 @@ if (( $# )); then
         case "${arg}" in
           (release|upgrade)
             COMMAND_INFO="${arg}"
+          ;;
+          (-*)
+            __help; error_message "No deploy type found. Use release|upgrade\n"; exit 2
           ;;
           (*)
             __help; error_message "Unknown deploy type ${arg}. Use release|upgrade\n"; exit 2
@@ -144,6 +150,9 @@ if (( $# )); then
           (release|config)
             CHECK_CMD="${arg}"
           ;;
+          (-*)
+            __help; error_message "No check type found. Use release|config\n"; exit 2
+          ;;
           (*)
             __help; error_message "Unknown check type ${arg}. Use release|config\n"; exit 2
           ;;
@@ -159,6 +168,9 @@ if (( $# )); then
         case "${arg}" in
           (release|upgrade)
             COMMAND_INFO="${arg}"
+          ;;
+          (-*)
+            __help; error_message "No release type found. Use release|upgrade\n"; exit 2
           ;;
           (*)
             __help; error_message "Unknown release type ${arg}. Use release|upgrade\n"; exit 2
@@ -205,6 +217,9 @@ if (( $# )); then
               NODE_ENVIRONMENT="staging"
             fi
           ;;
+          (-*)
+            __help; error_message "No show command found. Use releases|appups|relups\n"; exit 2
+          ;;
           (*)
             __help; error_message "Unknown show command ${arg}. Use releases|appups|relups\n"; exit 2
           ;;
@@ -248,6 +263,9 @@ if (( $# )); then
           (relup|relups)
             COMMAND_INFO="relup"
           ;;
+          (-*)
+            __help; error_message "No edit command found. Use appup|relup\n"; exit 2
+          ;;
           (*)
             __help; error_message "Unknown edit command ${arg}. Use appup|relup\n"; exit 2
           ;;
@@ -269,8 +287,11 @@ if (( $# )); then
             INCREASE_VERSION_TYPE="$arg"
             COMMAND_INFO="versions"
           ;;
+          (-*)
+            __help; error_message "Increase type not found. Use versions|major|minor\n"; exit 2
+          ;;
           (*)
-            __help; error_message "Unknown increase command ${arg}. Use versions|major|minor\n"; exit 2
+            __help; error_message "Unknown increase type ${arg}. Use versions|major|minor\n"; exit 2
           ;;
         esac
       else

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -49,8 +49,9 @@ __help() {
       --skip-mix-clean  Skip the 'mix clean step' for faster builds. Use in addition to --skip-git-clean
       --skip-relup-mod  Skip modification of relup file. Custom relup instructions are not added
       --relup-mod=<module-name> The name of the module to modify the relup
-      --auto-version=[patch|minor|major|git] Automatically increases the patch, minor or major version
-                        or appends the git sha1 revision to the current version
+      --auto-version=revision|commit-count|branch|date Automatically append metadata to release version.
+      --increment-version=major|minor|patch Increase the version for the current build.
+      --set-version=<release-version> Set the release version for the current build.
       --start-deploy    Starts the deployed release. If release is running, it is restarted!
       --host=[u@]vwx.yz Run command only on that host, even if different hosts are configured
       --mix-env=<env>   Build with custom mix env $MIX_ENV. Default is 'prod'
@@ -348,6 +349,9 @@ do
     ;;
     (--skip-mix-clean)
       SKIP_MIX_CLEAN="true"
+      [[ -n "$SET_RELEASE_VERSION" ]] && __help && error_message "Option --set-version= cannot be used together with the --skip-mix-clean option.\n" && exit 2
+      [[ -n "$INCREMENT_RELEASE_VERSION" ]] && __help && error_message "Option --increment-version= cannot be used together with the --skip-mix-clean option.\n" && exit 2
+      [[ -n "$AUTO_RELEASE_VERSION" ]] && __help && error_message "Option --auto-version= cannot be used together with the --skip-mix-clean option.\n" && exit 2
     ;;
     (--start-deploy)
       START_DEPLOY="true"
@@ -397,6 +401,28 @@ do
         RELUP_MODIFICATION_MODULE=${arg##--relup-mod=}
       elif [[ "${arg}" =~ ^--auto-version= ]]; then
         AUTO_RELEASE_VERSION=${arg##--auto-version=}
+        IFS='+' read -ra AUTO_VERSION_ARGS <<< "$AUTO_RELEASE_VERSION"
+        for AUTO_VERSION_ARG in "${AUTO_VERSION_ARGS[@]}"; do
+          ORIGINAL_AUTO_VERSION_ARG=$AUTO_VERSION_ARG
+          AUTO_VERSION_ARG=${AUTO_VERSION_ARG#append-*}
+          AUTO_VERSION_ARG=${AUTO_VERSION_ARG#git-*}
+          AUTO_VERSION_ARG=${AUTO_VERSION_ARG#build-*}
+          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|branch|date)$ ]]; then
+            __help; error_message "Illegal value for --auto-version= option: '${ORIGINAL_AUTO_VERSION_ARG}'.\n"; exit 2
+          fi
+        done
+        unset AUTO_VERSION_ARGS AUTO_VERSION_ARG ORIGINAL_AUTO_VERSION_ARG
+        [[ "$SKIP_MIX_CLEAN" = "true" ]] && __help && error_message "Option --auto-version= cannot be used together with the --skip-mix-clean option.\n" && exit 2
+      elif [[ "${arg}" =~ ^--increment-version= ]]; then
+        INCREMENT_RELEASE_VERSION=${arg##--increment-version=}
+        ! [[ "$INCREMENT_RELEASE_VERSION" =~  ^(patch|minor|major)$ ]] && __help && error_message "Value for --increment-version= option must be either patch, minor or major.\n" && exit 2
+        [[ -n "$SET_RELEASE_VERSION" ]] && __help && error_message "Option --increment-version= cannot be used together with the --set-version= option.\n" && exit 2
+        [[ "$SKIP_MIX_CLEAN" = "true" ]] && __help && error_message "Option --set-version= cannot be used together with the --skip-mix-clean option.\n" && exit 2
+      elif [[ "${arg}" =~ ^--set-version= ]]; then
+        SET_RELEASE_VERSION=${arg##--set-version=}
+        [[ -z "$SET_RELEASE_VERSION" ]] && __help && error_message "Value for --set-version= option must not be empty.\n" && exit 2
+        [[ -n "$INCREMENT_RELEASE_VERSION" ]] && __help && error_message "Option --set-version= cannot be used together with the --increment-version= option.\n" && exit 2
+        [[ "$SKIP_MIX_CLEAN" = "true" ]] && __help && error_message "Option --increment-version= cannot be used together with the --skip-mix-clean option.\n" && exit 2
       else
         [[ -n "${COMMAND}" ]] && __exec_if_defined "accepts_custom_command_argument" "${COMMAND}" "${arg}" || hint_message "Unknown argument ${arg} ignored"
       fi

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -407,7 +407,7 @@ do
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#append-*}
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#git-*}
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#build-*}
-          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|branch|date)$ ]]; then
+          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|commit-count-branch|commit-count-all|commit-count-all-branches|branch|date)$ ]]; then
             __help; error_message "Illegal value for --auto-version= option: '${ORIGINAL_AUTO_VERSION_ARG}'.\n"; exit 2
           fi
         done

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Edeliver.Mixfile do
 
   defp deps, do: [
     {:exrm, ">= 0.16.0"},
+    {:meck, "~> 0.8.4", only: :test},
   ]
 
 end

--- a/strategies/erlang-build-release
+++ b/strategies/erlang-build-release
@@ -22,12 +22,14 @@ ${txtbld}Options:${txtrst}
              passed as ${bldwht}--branch=${txtrst} argument or in the master (default).
   --mix-env=<env> Build the release with a custom mix environment.
              Default is ${bldwht}prod${txtrst}.
-  --auto-version=[git-]revision|[git-]commit-count|[git-]branch|[build-]date
-             ${txtgrn}Appends${txtrst} the git sha1 revision, the current commit count (across
-             all branches), the current branch name and/or the build date as
-             ${txtgrn}metadata to the current release version${txtrst}. To append that metadata
-             ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
-             in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
+  --auto-version=[git-]revision|[git-]commit-count[-all[-branches]|-branch]
+             |[git-]branch[-unless-master]|[build-]date ${txtgrn}Appends${txtrst} the git sha1
+             revision, the current commit count either across all branches
+             (default) or for the current branch, the current branch name
+             (optionally only unless it is the master branch) and/or the
+             build date as ${txtgrn}metadata to the current upgrade version${txtrst}. To append
+             that metadata ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst}
+             env in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
              e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
   --increment-version=major|minor|patch  Increments the major, minor or patch
              version ${txtylw}for the current build${txtrst}.

--- a/strategies/erlang-build-release
+++ b/strategies/erlang-build-release
@@ -29,7 +29,7 @@ ${txtbld}Options:${txtrst}
              ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
              in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
              e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
-  --increment-version=major|minor|patch  Increases the major, minor or patch
+  --increment-version=major|minor|patch  Increments the major, minor or patch
              version ${txtylw}for the current build${txtrst}.
   --set-version=<release-version> Sets the release version for ${txtylw}the current build${txtrst}.
 

--- a/strategies/erlang-build-release
+++ b/strategies/erlang-build-release
@@ -22,10 +22,16 @@ ${txtbld}Options:${txtrst}
              passed as ${bldwht}--branch=${txtrst} argument or in the master (default).
   --mix-env=<env> Build the release with a custom mix environment.
              Default is ${bldwht}prod${txtrst}.
-  --auto-version=[patch|minor|major|git] Automatically increases the patch,
-             minor or major version of the release or appends the git sha1
-             revision to the current version. If any other term is used
-             that string is used as the version of the new release.
+  --auto-version=[git-]revision|[git-]commit-count|[git-]branch|[build-]date
+             ${txtgrn}Appends${txtrst} the git sha1 revision, the current commit count (across
+             all branches), the current branch name and/or the build date as
+             ${txtgrn}metadata to the current release version${txtrst}. To append that metadata
+             ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
+             in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
+             e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
+  --increment-version=major|minor|patch  Increases the major, minor or patch
+             version ${txtylw}for the current build${txtrst}.
+  --set-version=<release-version> Sets the release version for ${txtylw}the current build${txtrst}.
 
 ${txtbld}Faster Builds:${txtrst} ${txtblu}(Faster builds might fail during build or during runtime)${txtrst}
   --skip-git-clean Don't build from a clean state for faster builds. Can be

--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -43,7 +43,7 @@ ${txtbld}Options:${txtrst}
              ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
              in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
              e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
-  --increment-version=major|minor|patch  Increases the major, minor or patch
+  --increment-version=major|minor|patch  Increments the major, minor or patch
              version ${txtylw}for the current build${txtrst}.
   --set-version=<release-version> Sets the release version for ${txtylw}the current build${txtrst}.
 

--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -33,12 +33,19 @@ ${txtbld}Options:${txtrst}
              Default is ${bldwht}prod${txtrst}.
   --skip-relup-mod Skip modification of the grenerated relup instructions.
              No custom relup instructions are added.
-  --relup-mod=<module-name> The name of the module to modify the relup if there are several modules. The module
-             must implement the Behaviour Edeliver.Relup.Modification.
-  --auto-version=[patch|minor|major|git] Automatically increases the patch,
-             minor or major version of the upgrade or appends the git sha1
-             revision to the current version. If any other term is used
-             that string is used as the version of the new upgrade.
+  --relup-mod=<module-name> The name of the module to modify the relup
+             if there are several modules. The module must implement the
+              Behaviour ${bldwht}Edeliver.Relup.Modification${txtrst}.
+  --auto-version=[git-]revision|[git-]commit-count|[git-]branch|[build-]date
+             ${txtgrn}Appends${txtrst} the git sha1 revision, the current commit count (across
+             all branches), the current branch name and/or the build date as
+             ${txtgrn}metadata to the current upgrade version${txtrst}. To append that metadata
+             ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
+             in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
+             e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
+  --increment-version=major|minor|patch  Increases the major, minor or patch
+             version ${txtylw}for the current build${txtrst}.
+  --set-version=<release-version> Sets the release version for ${txtylw}the current build${txtrst}.
 
 ${txtbld}Faster Builds:${txtrst} ${txtblu}(Faster builds might fail during build or during runtime)${txtrst}
   --skip-git-clean Don't build from a clean state for faster builds. Can be

--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -36,12 +36,14 @@ ${txtbld}Options:${txtrst}
   --relup-mod=<module-name> The name of the module to modify the relup
              if there are several modules. The module must implement the
               Behaviour ${bldwht}Edeliver.Relup.Modification${txtrst}.
-  --auto-version=[git-]revision|[git-]commit-count|[git-]branch|[build-]date
-             ${txtgrn}Appends${txtrst} the git sha1 revision, the current commit count (across
-             all branches), the current branch name and/or the build date as
-             ${txtgrn}metadata to the current upgrade version${txtrst}. To append that metadata
-             ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
-             in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
+  --auto-version=[git-]revision|[git-]commit-count[-all[-branches]|-branch]
+             |[git-]branch[-unless-master]|[build-]date ${txtgrn}Appends${txtrst} the git sha1
+             revision, the current commit count either across all branches
+             (default) or for the current branch, the current branch name
+             (optionally only unless it is the master branch) and/or the
+             build date as ${txtgrn}metadata to the current upgrade version${txtrst}. To append
+             that metadata ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst}
+             env in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
              e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
   --increment-version=major|minor|patch  Increments the major, minor or patch
              version ${txtylw}for the current build${txtrst}.

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -157,7 +157,7 @@ __format_response() {
     local _is_first_line="true" _line _revision="$(grep -oe '[0-9a-fA-F]\{7\}' <<< "$_response")"
     if [[ -n "$_revision" ]]; then
       echo -e "${txtylw}$_response${txtrst}"
-      local _branch="$(git branch -a --contains "$_revision" | cut -b3-)"
+      local _branch="$(git branch -a --contains "$_revision" | head -n 1 | cut -b3-)"
       [[ -n "$_branch" ]] && echo -e "  branch  : ${_branch}"
       echo "  revision: $_revision"
       local _commit_date="$(git show -s --format=%ci "$_revision" 2>/dev/null)"

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -7,6 +7,59 @@ REQUIRED_CONFIGS+=("NODE_ENVIRONMENT")
 
 require_node_config
 
+help() {
+  case "$NODE_ACTION" in
+    (start|stop|restart|ping|version)
+      echo -e "
+${bldwht}Usage:${txtrst}
+  edeliver $NODE_ACTION [staging|production] [Options]
+
+${txtbld}Options:${txtrst}
+  --host=[u@]vwx.yz Run command only on that host,
+                    even if different hosts are configured"
+    case "$NODE_ACTION" in
+        (start)    echo -e "\n${bldylw}Info:${txtrst} Starts the node(s) on the deploy hosts.\n" ;;
+        (stop)     echo -e "\n${bldylw}Info:${txtrst} Stops the node(s) on the deploy hosts.\n" ;;
+        (restart)  echo -e "\n${bldylw}Info:${txtrst} Restarts the application on the deploy host(s) (not the emulator).\n" ;;
+        (ping)     echo -e "\n${bldylw}Info:${txtrst} Checks whether the node(s) on the deploy host(s)\n      are running.\n" ;;
+        (version)  echo -e "\n${bldylw}Info:${txtrst} Displays the running version(s) on the deploy host(s).\n" ;;
+    esac
+    ;;
+    (migrate)
+      echo -e "
+${bldwht}Usage:${txtrst}
+  edeliver migrate [staging|production] [up|down] [--version=<migration-version>]
+
+${txtbld}Options:${txtrst}
+  --host=[u@]vwx.yz Run migrations only on that host,
+                    even if different hosts are configured
+  --version=<migration-version> The version to migrate to.
+
+${bldylw}Info:${txtrst}
+  Migrates the database schema on the deploy host(s) either
+  ${bldwht}up${txtrst} or ${bldwht}down${txtrst}. Make sure the release / upgrade containing
+  the migrations is installed before.
+    "
+    ;;
+    (migrations)
+      echo -e "
+${bldwht}Usage:${txtrst}
+  edeliver [show] migrations [on] [staging|production]
+
+${txtbld}Options:${txtrst}
+  --host=[u@]vwx.yz Show migrations only from that host,
+                    even if different hosts are configured
+
+${bldylw}Info:${txtrst} Shows the pending migration on the deploy host(s).
+    "
+    ;;
+    (*)
+      [[ -n "$COMMAND_INFO" ]] && local _command="$COMMAND $COMMAND_INFO" || local _command="$COMMAND"
+      error "\nNo custom help provided for command '$_command'. Try --help option.\n"
+    ;;
+  esac
+}
+
 run() {
   [[ "$NODE_ACTION" = version ]] && status "getting release versions from $NODE_ENVIRONMENT servers" || status "${NODE_ACTION}ing $NODE_ENVIRONMENT servers"
   authorize_hosts
@@ -90,8 +143,43 @@ __execute_node_command_synchronously() {
   local _node=${NODES# *}
   __print_node_command_result "single_node" "0" "$_node" ""
   echo -n "  response: "
-  __execute_node_command "single_node" "$_node" "$_node_command"
+  local _response=$(__execute_node_command "single_node" "$_node" "$_node_command")
+  __format_response "$_response"
 }
+
+# formats the response when node command is executed
+# synchronously. If version is displayed and --verbose option passed
+# the last git revisions are displayed in addition if the version
+# contains the git revsion.
+__format_response() {
+  local _response="$@"
+  if [[ "$COMMAND" = "version" ]] && [[ "$_response" =~ "+" ]]; then
+    local _is_first_line="true" _line _revision="$(grep -oe '[0-9a-fA-F]\{7\}' <<< "$_response")"
+    if [[ -n "$_revision" ]]; then
+      echo -e "${txtylw}$_response${txtrst}"
+      local _branch="$(git branch -a --contains "$_revision" | cut -b3-)"
+      [[ -n "$_branch" ]] && echo -e "  branch  : ${_branch}"
+      echo "  revision: $_revision"
+      local _commit_date="$(git show -s --format=%ci "$_revision" 2>/dev/null)"
+      [[ -n "$_commit_date" ]] && echo -e "  date    : $_commit_date (git commit)"
+      local _last_commits=${VERSION_INFO_LAST_COMMITS:-5}
+      (IFS='
+'
+      for _line in $(git log "$_revision" -"$_last_commits" --pretty=oneline 2>/dev/null | cut -d" " -f2-); do
+        _line="$(xargs <<< "$_line")"
+        [[ "$_is_first_line" = "true" ]] && echo -n "  commits : " || echo -n "            "
+        echo -e "$_line"
+        _is_first_line="false"
+      done
+      [[ "$_is_first_line" = "false" ]] && [[ "$_last_commits" != "1" ]] && echo "            ..."
+      )
+      return 0
+    fi
+  fi
+  echo "${bldylw}$_response${txtrst}"
+
+}
+
 
 # executes a node command on a given node.
 __execute_node_command() {
@@ -159,7 +247,8 @@ __print_node_command_result() {
   if [[ "$_node_index" = "single_node" ]]; then
     echo -en "${_message}" && return 0
   elif [[ "$_status_code" = "0" ]] && [[ -n "$_node_index" ]]; then
-    _message="${_message}  response: ${bldylw}${_node_action_response}${txtrst}\n"
+    _node_action_response="$(__format_response "$_node_action_response")"
+    _message="${_message}  response: ${_node_action_response}\n"
   elif [[ -n "$_node_index" ]]; then
     _message="${_message}  response: ${bldred}failed${txtrst}\n";
     [[ -n "$_node_action_response" ]] && {

--- a/strategies/erlang-upgrade
+++ b/strategies/erlang-upgrade
@@ -30,13 +30,16 @@ ${txtbld}Options:${txtrst}
   --relup-mod=<module-name> The name of the module to modify the relup
              if there are several modules. The module must implement
              the Behaviour Edeliver.Relup.Modification.
-  --auto-version=[patch|minor|major|git] Automatically increases the patch,
-             minor or major version of the upgrade or appends the git sha1
-             revision to the current version. If any other term is used
-             that string is used as the version of the new upgrade. It is
-             ${txtgrn}recommended to enable${txtrst} the git-auto-revision ${txtgrn}permanently${txtrst}
-             for automatic upgrades by setting ${bldwht}AUTO_RELEASE_VERSION=git${txtrst}
-             in the config.
+  --auto-version=[git-]revision|[git-]commit-count|[git-]branch|[build-]date
+             ${txtgrn}Appends${txtrst} the git sha1 revision, the current commit count (across
+             all branches), the current branch name and/or the build date as
+             ${txtgrn}metadata to the current release version${txtrst}. To append that metadata
+             ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
+             in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
+             e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
+  --increment-version=major|minor|patch  Increases the major, minor or patch
+             version ${txtylw}for the current build${txtrst}.
+  --set-version=<release-version> Sets the release version for ${txtylw}the current build${txtrst}.
 
 ${txtbld}Faster Builds:${txtrst} ${txtblu}(Faster builds might fail during build or during runtime)${txtrst}
   --skip-git-clean Don't build from a clean state for faster builds. Can be

--- a/strategies/erlang-upgrade
+++ b/strategies/erlang-upgrade
@@ -30,12 +30,14 @@ ${txtbld}Options:${txtrst}
   --relup-mod=<module-name> The name of the module to modify the relup
              if there are several modules. The module must implement
              the Behaviour Edeliver.Relup.Modification.
-  --auto-version=[git-]revision|[git-]commit-count|[git-]branch|[build-]date
-             ${txtgrn}Appends${txtrst} the git sha1 revision, the current commit count (across
-             all branches), the current branch name and/or the build date as
-             ${txtgrn}metadata to the current release version${txtrst}. To append that metadata
-             ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
-             in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
+  --auto-version=[git-]revision|[git-]commit-count[-all[-branches]|-branch]
+             |[git-]branch[-unless-master]|[build-]date ${txtgrn}Appends${txtrst} the git sha1
+             revision, the current commit count either across all branches
+             (default) or for the current branch, the current branch name
+             (optionally only unless it is the master branch) and/or the
+             build date as ${txtgrn}metadata to the current upgrade version${txtrst}. To append
+             that metadata ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst}
+             env in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
              e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
   --increment-version=major|minor|patch  Increments the major, minor or patch
              version ${txtylw}for the current build${txtrst}.

--- a/strategies/erlang-upgrade
+++ b/strategies/erlang-upgrade
@@ -37,7 +37,7 @@ ${txtbld}Options:${txtrst}
              ${txtgrn}automatically for each build${txtrst} set the ${bldwht}AUTO_VERSION${txtrst} env
              in the config. Values can also be combined using the ${bldwht}+${txtrst} char,
              e.g. ${bldwht}git-revison+git-branch${txtrst} creates version 1.2.3-82a5834-master.
-  --increment-version=major|minor|patch  Increases the major, minor or patch
+  --increment-version=major|minor|patch  Increments the major, minor or patch
              version ${txtylw}for the current build${txtrst}.
   --set-version=<release-version> Sets the release version for ${txtylw}the current build${txtrst}.
 

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -203,6 +203,11 @@ defmodule Edeliver.Release.Version.Test do
     end)
   end
 
+  test "use valid semver for branch metadata" do
+    assert "foo-bar-123" = valid_semver_metadata("foo-bar-123")
+    assert "foo-barbaz" = valid_semver_metadata("foo-bar.baz")
+    assert "foo-barz" = valid_semver_metadata("foo-barüz")
+  end
 
   ### test helpers ####
 

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -127,6 +127,13 @@ defmodule Edeliver.Release.Version.Test do
     assert {:modified, "1.2.1+12345-82a5834-feature-xyz"} = modify_version_with_args "1.2", "patch commit-count revision branch"
   end
 
+  test "appending metadata and increasing version" do
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "append-git-revision increase major version "
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "git-revision+major"
+    assert {:modified, "2.2.0+82a5834-12345-feature-xyz"} = modify_version_with_args "2.1.3", "append-git-revision increase minor append-commit-count append-branch"
+    assert {:modified, "1.2.1+12345-82a5834-feature-xyz"} = modify_version_with_args "1.2", "commit-count revision patch branch"
+  end
+
   test "use AUTO_VERSION env as default" do
     assert :ok = System.put_env("AUTO_VERSION", "append-commit-count append-git-branch")
     assert {:modified, "1.0.0+12345-feature-xyz"} = modify_version_with_args "1.0.0", ""

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -8,9 +8,10 @@ defmodule Edeliver.Release.Version.Test do
   setup_all do
     :meck.new ReleaseVersion, [:passthrough]
     :meck.expect(ReleaseVersion, :get_git_revision, fn -> "82a5834" end)
-    :meck.expect(ReleaseVersion, :get_commit_count, fn ->   "12345" end)
-    :meck.expect(ReleaseVersion, :get_branch, fn ->   "feature-xyz" end)
-    :meck.expect(ReleaseVersion, :get_date, fn ->      "20160414" end)
+    :meck.expect(ReleaseVersion, :get_commit_count, fn -> "12345" end)
+    :meck.expect(ReleaseVersion, :get_commit_count_branch, fn ->   "4321" end)
+    :meck.expect(ReleaseVersion, :get_branch, fn -> "feature-xyz" end)
+    :meck.expect(ReleaseVersion, :get_date, fn -> "20160414" end)
     :ok
   end
 
@@ -41,9 +42,19 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "appending commit count" do
+    assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "append-git-commit-count-all"
+    assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "append-git-commit-count-all-branches"
+    assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "git-commit-count-all-branches"
+    assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "commit-count-all"
     assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "append-git-commit-count"
     assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "append-commit-count"
     assert {:modified, "1.1.0+12345"} = modify_version_with_args "1.1.0", "commit-count"
+  end
+
+  test "appending commit count for current branch" do
+    assert {:modified, "1.0.0+4321"} = modify_version_with_args "1.0.0", "append-git-commit-count-branch"
+    assert {:modified, "1.0.0+4321"} = modify_version_with_args "1.0.0", "git-commit-count-branch"
+    assert {:modified, "1.0.0+4321"} = modify_version_with_args "1.0.0", "commit-count-branch"
   end
 
   test "appending git revision" do

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -44,6 +44,7 @@ defmodule Edeliver.Release.Version.Test do
 
 
   test "appending commit count" do
+    assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "append-git-commit-count"
     assert {:modified, "1.0.0+12345"} = modify_version_with_args "1.0.0", "append-commit-count"
     assert {:modified, "1.1.0+12345"} = modify_version_with_args "1.1.0", "commit-count"
   end

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -10,7 +10,7 @@ defmodule Edeliver.Release.Version.Test do
     :meck.expect(ReleaseVersion, :get_git_revision, fn -> "82a5834" end)
     :meck.expect(ReleaseVersion, :get_commit_count, fn ->   "12345" end)
     :meck.expect(ReleaseVersion, :get_branch, fn ->   "feature-xyz" end)
-    :meck.expect(ReleaseVersion, :get_date, fn ->      "2016.04.14" end)
+    :meck.expect(ReleaseVersion, :get_date, fn ->      "20160414" end)
     :ok
   end
 
@@ -27,7 +27,7 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "mocking get current date" do
-    assert "2016.04.14" = get_date
+    assert "20160414" = get_date
   end
 
   test "printing current release version for show argument" do
@@ -62,9 +62,9 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "appending date" do
-    assert {:modified, "1.0.0+2016.04.14"} = modify_version_with_args "1.0.0", "append-build-date"
-    assert {:modified, "1.0.1+2016.04.14"} = modify_version_with_args "1.0.1", "build-date"
-    assert {:modified, "1.2.3+2016.04.14"} = modify_version_with_args "1.2.3", "date"
+    assert {:modified, "1.0.0+20160414"} = modify_version_with_args "1.0.0", "append-build-date"
+    assert {:modified, "1.0.1+20160414"} = modify_version_with_args "1.0.1", "build-date"
+    assert {:modified, "1.2.3+20160414"} = modify_version_with_args "1.2.3", "date"
   end
 
   test "appending commit count and git revision" do

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -79,37 +79,37 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "increasing patch version" do
-    assert {:modified, "1.0.1"} = modify_version_with_args "1.0.0", "increase patch"
-    assert {:modified, "1.0.1"} = modify_version_with_args "1.0.0", "increase patch version"
+    assert {:modified, "1.0.1"} = modify_version_with_args "1.0.0", "increment patch"
+    assert {:modified, "1.0.1"} = modify_version_with_args "1.0.0", "increment patch version"
     assert {:modified, "1.0.1"} = modify_version_with_args "1.0.0", "patch"
-    assert {:modified, "1.2.4"} = modify_version_with_args "1.2.3", "increase patch"
+    assert {:modified, "1.2.4"} = modify_version_with_args "1.2.3", "increment patch"
     assert {:modified, "1.2.4"} = modify_version_with_args "1.2.3", "patch"
     assert {:modified, "1.2.1"} = modify_version_with_args "1.2", "patch"
-    assert {:modified, "1.0.1"} = modify_version_with_args "1", "increase patch"
+    assert {:modified, "1.0.1"} = modify_version_with_args "1", "increment patch"
   end
 
   test "increasing minor version" do
-    assert {:modified, "1.1.0"} = modify_version_with_args "1.0.0", "increase minor"
-    assert {:modified, "1.1.0"} = modify_version_with_args "1.0.0", "increase minor version"
+    assert {:modified, "1.1.0"} = modify_version_with_args "1.0.0", "increment minor"
+    assert {:modified, "1.1.0"} = modify_version_with_args "1.0.0", "increment minor version"
     assert {:modified, "1.1.0"} = modify_version_with_args "1.0.0", "minor"
-    assert {:modified, "2.2.0"} = modify_version_with_args "2.1.3", "increase minor"
+    assert {:modified, "2.2.0"} = modify_version_with_args "2.1.3", "increment minor"
     assert {:modified, "1.3.0"} = modify_version_with_args "1.2.0", "minor"
     assert {:modified, "1.3.0"} = modify_version_with_args "1.2", "minor"
-    assert {:modified, "2.1.0"} = modify_version_with_args "2", "increase minor"
+    assert {:modified, "2.1.0"} = modify_version_with_args "2", "increment minor"
   end
 
   test "increasing major version" do
-    assert {:modified, "2.0.0"} = modify_version_with_args "1.0.0", "increase major"
+    assert {:modified, "2.0.0"} = modify_version_with_args "1.0.0", "increment major"
     assert {:modified, "2.0.0"} = modify_version_with_args "1.0.0", "major"
-    assert {:modified, "3.0.0"} = modify_version_with_args "2.1.3", "increase major"
-    assert {:modified, "3.0.0"} = modify_version_with_args "2.1.3", "increase major version"
+    assert {:modified, "3.0.0"} = modify_version_with_args "2.1.3", "increment major"
+    assert {:modified, "3.0.0"} = modify_version_with_args "2.1.3", "increment major version"
     assert {:modified, "2.0.0"} = modify_version_with_args "1.2.0", "major"
     assert {:modified, "2.0.0"} = modify_version_with_args "1.2", "major"
-    assert {:modified, "5.0.0"} = modify_version_with_args "4", "increase major"
+    assert {:modified, "5.0.0"} = modify_version_with_args "4", "increment major"
   end
 
   test "get version to set from args" do
-    assert {_version_to_set = nil, ["increase", "major"]} = get_version_to_set_from_args("increase major" |> to_argv(), [])
+    assert {_version_to_set = nil, ["increment", "major"]} = get_version_to_set_from_args("increment major" |> to_argv(), [])
     assert {_version_to_set = "2.0.0-beta", ["set"]} = get_version_to_set_from_args("set 2.0.0-beta" |> to_argv(), [])
     assert {_version_to_set = "2.1.0-beta.1", ["set", "append-commit-count"]} = get_version_to_set_from_args("set 2.1.0-beta.1 append-commit-count" |> to_argv(), [])
   end
@@ -121,16 +121,16 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "increasing version and appending metadata" do
-    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "increase major version append-git-revision"
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "increment major version append-git-revision"
     assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "major+git-revision"
-    assert {:modified, "2.2.0+82a5834-12345-feature-xyz"} = modify_version_with_args "2.1.3", "increase minor append-git-revision append-commit-count append-branch"
+    assert {:modified, "2.2.0+82a5834-12345-feature-xyz"} = modify_version_with_args "2.1.3", "increment minor append-git-revision append-commit-count append-branch"
     assert {:modified, "1.2.1+12345-82a5834-feature-xyz"} = modify_version_with_args "1.2", "patch commit-count revision branch"
   end
 
   test "appending metadata and increasing version" do
-    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "append-git-revision increase major version "
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "append-git-revision increment major version "
     assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "git-revision+major"
-    assert {:modified, "2.2.0+82a5834-12345-feature-xyz"} = modify_version_with_args "2.1.3", "append-git-revision increase minor append-commit-count append-branch"
+    assert {:modified, "2.2.0+82a5834-12345-feature-xyz"} = modify_version_with_args "2.1.3", "append-git-revision increment minor append-commit-count append-branch"
     assert {:modified, "1.2.1+12345-82a5834-feature-xyz"} = modify_version_with_args "1.2", "commit-count revision patch branch"
   end
 
@@ -160,11 +160,11 @@ defmodule Edeliver.Release.Version.Test do
     assert {:modified, "1.0.0+82a5834"} = modify_version_with_args "1.0.0", ""
   end
 
-  test "AUTO_VERSION should be used in conjunction with increase major|minor|patch or set version" do
+  test "AUTO_VERSION should be used in conjunction with increment major|minor|patch or set version" do
     assert :ok = System.put_env("AUTO_VERSION", "append-git-revision")
-    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "increase major"
-    assert {:modified, "1.1.0+82a5834"} = modify_version_with_args "1.0.0", "increase minor"
-    assert {:modified, "1.0.1+82a5834"} = modify_version_with_args "1.0.0", "increase patch"
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "increment major"
+    assert {:modified, "1.1.0+82a5834"} = modify_version_with_args "1.0.0", "increment minor"
+    assert {:modified, "1.0.1+82a5834"} = modify_version_with_args "1.0.0", "increment patch"
     assert {:modified, "2.0.0-beta+82a5834"} = modify_version_with_args "1.0.0", "set 2.0.0-beta"
   end
 
@@ -199,7 +199,7 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "should fail if increasing or setting version is used in AUTO_VERSION env" do
-    assert :ok = System.put_env("AUTO_VERSION", "increase minor")
+    assert :ok = System.put_env("AUTO_VERSION", "increment minor")
     assert <<_,_,_,_,_>> <> "Error: Increasing major|minor|path or setting version is not allowed" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", ""
     end)

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -159,10 +159,10 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "should fail for illegal major, minor or patch combinations" do
-    assert <<_,_,_,_,_>> <> "Error: Illegal combination of options:" <> _ = capture_io(:stderr, fn ->
+    assert <<_,_,_,_,_>> <> "Error: Illegal combination of options" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", "major minor"
     end)
-    assert <<_,_,_,_,_>> <> "Error: Illegal combination of options:" <> _ = capture_io(:stderr, fn ->
+    assert <<_,_,_,_,_>> <> "Error: Illegal combination of options" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", "major set 2.0.0-beta"
     end)
   end
@@ -174,10 +174,10 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "should fail if version to set is missing" do
-    assert <<_,_,_,_,_>> <> "Error: No version to set. Please add the version as argument" <> _ = capture_io(:stderr, fn ->
+    assert <<_,_,_,_,_>> <> "Error: No version to set for 'release.version' task. Please add the version as argument" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", "set"
     end)
-    assert <<_,_,_,_,_>> <> "Error: No version to set. Please add the version as argument" <> _ = capture_io(:stderr, fn ->
+    assert <<_,_,_,_,_>> <> "Error: No version to set for 'release.version' task. Please add the version as argument" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", "set append-commit-count"
     end)
   end
@@ -195,7 +195,7 @@ defmodule Edeliver.Release.Version.Test do
 
   test "should fail if no args are set and no AUTO_VERSION env is set" do
     assert :ok = System.delete_env("AUTO_VERSION")
-    assert <<_,_,_,_,_>> <> "Error: No arguments passed and no AUTO_VERSION env is set" <> _ = capture_io(:stderr, fn ->
+    assert <<_,_,_,_,_>> <> "Error: No arguments passed to 'release.version' task and no AUTO_VERSION env is set" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", ""
     end)
   end

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -134,6 +134,11 @@ defmodule Edeliver.Release.Version.Test do
     assert {:modified, "1.2.1+12345-82a5834-feature-xyz"} = modify_version_with_args "1.2", "commit-count revision patch branch"
   end
 
+  test "ignore leading or tailing concatenation character (+)" do
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "git-revision+major+"
+    assert {:modified, "2.0.0+82a5834"} = modify_version_with_args "1.0.0", "+git-revision+major"
+  end
+
   test "use AUTO_VERSION env as default" do
     assert :ok = System.put_env("AUTO_VERSION", "append-commit-count append-git-branch")
     assert {:modified, "1.0.0+12345-feature-xyz"} = modify_version_with_args "1.0.0", ""

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -14,6 +14,10 @@ defmodule Edeliver.Release.Version.Test do
     :ok
   end
 
+  setup do
+    assert :ok = System.delete_env("AUTO_VERSION")
+  end
+
   test "mocking get git revision" do
     assert "82a5834" = get_git_revision
   end
@@ -194,7 +198,6 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "should fail if no args are set and no AUTO_VERSION env is set" do
-    assert :ok = System.delete_env("AUTO_VERSION")
     assert <<_,_,_,_,_>> <> "Error: No arguments passed to 'release.version' task and no AUTO_VERSION env is set" <> _ = capture_io(:stderr, fn ->
       assert :error = modify_version_with_args "1.0.0", ""
     end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,4 @@
+
+
+
+ExUnit.start()


### PR DESCRIPTION
Implement auto-versioning by appending metadata like git commit count, git revision, branch etc. to the release version when building releases and upgrades. 
Also add the ability to auto-increment the version for the current build.

Updating and identifying the version is essential especially when building upgrades.

##### Append git commit count and/or revision to the release version

```sh
  mix release.version show
  1.0.0
  mix edeliver build release --auto-version=commit-count
  # creates version 1.0.0+3027
  mix edeliver build upgrade --auto-version=git-revision
  # creates version 1.0.0+82a5834
  mix edeliver build upgrade --auto-version=commit-count+git-revision
  # creates version 1.0.0+3027-82a5834
  mix edeliver build upgrade --auto-version=git-revision+commit-count
  # creates version 1.0.0+82a5834-3027
```

##### Append other metadata: git branch or build date

```sh
  mix release.version show
  1.0.0
  mix edeliver build release --auto-version=git-branch
  # creates version 1.0.0+master
  mix edeliver build release --auto-version=git-revision+git-branch-unless-master
  # creates version 1.0.0+82a5834
  mix edeliver build upgrade --auto-version=build-date
  # creates version 1.0.0+20160414
  mix edeliver build upgrade --auto-version=git-revision+build-date
  # creates version 1.0.0+82a5834-20160414
```

##### Append metadata to version permanentely

To append metadata permanentely, the `AUTO_VERSION` configuration variable in the `.deliver/config` file can be set. This can be overridden by the `--auto-version=` command line argument.

```sh
 # ./deliver/config
 AUTO_VERSION=commit-count+git-revision+branch-unless-master
```

##### Available metadata which can be appended to the release version


  * `[git-]revision` Appends sha1 git revision of current HEAD.
  * `[git-]branch` Appends the current branch that is built.
  * `[git-]branch-unless-master` Appends the current branch that is built but only unless it is the master branch.
  * `[build-]date` Appends the build date as YYYYMMDD.
  * `[git-]commit-count[-all[-branches]` Appends the number of commits across all branches.
    Allows edeliver to detect which version is newer if it is appended as first metadata to
    the release version.
  * `[git-]commit-count-branch` Appends the number of commits from the current branch.
    This makes more sense, if the branch name is also appended as metadata to avoid
    conflicts from different branches.


Using __commit count accross all branches__ (`commit-count[-all[-branches]`) __or__ using the __build date__ (`[build-]date`) __as first metadata__ to append, enables edeliver to __consider__ that values __when sorting__ versions. Using `[git-]revision` or commit count for the current branch in conjunction with the branch name (`commit-count-branch+branch`) allows to __uniquely identify__ the built/deployed __version__. edeliver will display the commit message for that version (and the 5 previous commit messages) if `edeliver version [staging|production]` is used.  To achieve both (sorting and identifying versions) and to see whether a feature branch is built/deployed, the following permanent auto-versioning option is recommended: `AUTO_VERSION=commit-count+git-revision+branch-unless-master`

More information are added to the edeliver help (`mix edeliver help upgrade`, `mix edeliver help release` and `mix help release.version`).

##### Increment / Set Version for the current release / upgrade

```sh
  mix release.version show
  1.2.3
  mix edeliver build release --increment-version=patch
  # creates version 1.2.4
  mix edeliver build release --increment-version=minor
  # creates version 1.3.0
  mix edeliver build release --increment-version=minor
  # creates version 2.0.0
  mix edeliver build release --set-version=1.3.0-beta.1
  # creates version 1.3.0-beta.1

```

`--increment-version=` and `--set-version=` can be used in conjunction with the `--auto-version=` option. The `AUTO_VERSION` default is also used unless the `--auto-version=` overrides it.

##### Use the Auto-Versioning / Increment-Version mix task locally

It is also possible to use the auto versioning mix task provided by edeliver locally. The argument names to append metadata differ slightly and contain an (optional) `append-` prefix. 

```sh
  mix release.version show
  1.2.3
  mix do clean, release.version increase major revision branch --dry-run
  Would update version from 1.2.3 to 2.0.0+82a5834-test
  # prints only the info above. You can always ommit the 'append-git-' part.
  mix do clean, release.version append-git-revision, release
  # creates version 1.2.3+82a5834
  mix do clean, release.version append-commit-count append-git-revision append-git-branch, release
  # creates version 1.2.3+3027-82a5834-master
  mix do clean, release.version increase major, release
  AUTO_VERSION="append-git-revision" mix do clean, release.version set 1.3.0-beta.1, release
  # creates version 1.3.0-beta.1+82a5834
```

Still to do:


- [x] Handle `--quiet` and `--verbose` options and forward them from edeliver
- [x] Implement the `set` option
- [x] Implement the `append-date` option
- [x] Add Documentation and help
- [x] Rename / Alias `increment` / `increase`
- [x] Allow to use commit-count from all branches or current branch
- [x] Sort versions by commit-count or build date
- [x] Display commit messages in `edeliver version` task 
