### PR TITLE
Fix syntax on migrate task with down operation

### DIFF
--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -18,7 +18,7 @@ run() {
     error "Showing migrations is only supported when using mix as release command."
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
     local __up_or_down="up"
-    for args in $ARGS; do [[ "$arg" = "down" ]] && local __up_or_down="down"; done
+    for arg in $ARGS; do [[ "$arg" = "down" ]] && local __up_or_down="down"; done
     [[ -n "$VERSION" ]] && local __to_version=", \"$VERSION\"" || local __to_version=""
     NODE_ACTION="rpc Elixir.Edeliver run_command '[[migrate, \"$APP\", ${__up_or_down}${__to_version}]].' | tail -n+2"
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" != "mix" ]]; then


### PR DESCRIPTION
The option `down` never gets evaluated because of the misspelling in the bash script.