### PR TITLE
Fix `upgrade` command for production deploy environment

### DIFF
--- a/strategies/erlang-upgrade
+++ b/strategies/erlang-upgrade
@@ -109,6 +109,9 @@ run() {
   [[ "${#_online_upgrade_hosts[@]}" -gt 0 && "${#_offline_deploy_hosts[@]}" -gt 0 ]] && status "Deploying upgrades to ${#_online_upgrade_hosts[@]} online and ${#_offline_deploy_hosts[@]} releases to offline hosts"
   [[ "${#_online_upgrade_hosts[@]}" -gt 0 ]] && status "Deploying upgrades to ${#_online_upgrade_hosts[@]} online hosts"
   [[ "${#_offline_deploy_hosts[@]}" -gt 0 ]] && status "Deploying ${#_offline_deploy_hosts[@]} releases to offline hosts"
+  # we need to store the actual DELIVER_TO directory here, because while building
+  # is is set to the BUILD_AT directory in set_build_hosts
+  local _deliver_to_directory="$DELIVER_TO"
   # build upgrade  <---------------------------------------------------------------------------------------------------
   local _built_upgrade=false _upgrade_version_to_install
   if [[ -n "$_running_release_version" && "${#_online_upgrade_hosts[@]}" -gt 0 ]]; then
@@ -147,6 +150,7 @@ run() {
       _upgrade_version_to_install="$RELEASE_VERSION"
     fi # building upgrade finished
     # deploy upgrade to online hosts running the same version <--------------------------------------------------------
+    DELIVER_TO="$_deliver_to_directory"
     status "Upgrading $DEPLOY_ENVIRONMENT hosts to version $_upgrade_version_to_install"
     HOSTS="${_online_upgrade_hosts[@]}"
     update_hosts_app_user
@@ -156,6 +160,7 @@ run() {
   fi
 
   # deploy clean release to offline hosts and start it <---------------------------------------------------------------
+  DELIVER_TO="$_deliver_to_directory"
   if [[  "${#_offline_deploy_hosts[@]}" -gt 0 ]]; then
     local _release_version_to_install="$_upgrade_version_to_install"
     if [[ "$_built_upgrade" != "true" ]]; then


### PR DESCRIPTION
If deploy environment is production, the deploy directory
`DELIVER_TO` was not set correctly because it is set to
`BUILD_AT` while building the upgrade. See #49