### PR TITLE
Synchronous start

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ __If using [mix](http://elixir-lang.org/getting_started/mix/1.html)__, add it as
 
 And run `mix do deps.get, deps.compile`. Edeliver is then available as __mix task__: `mix edeliver`.
 
-For __additional edeliver commands__ `version`, `migrate` and `show migrations` __add edeliver as application for your relase__ in the `mix.exs` file:
+For __additional edeliver commands__ `version`, `migrate` and `show migrations` __add edeliver as application for your release__ in the `mix.exs` file (should be the last application):
 
 	  def application, do: [
 	    applications: [

--- a/lib/edeliver.ex
+++ b/lib/edeliver.ex
@@ -1,12 +1,51 @@
 defmodule Edeliver do
 
+  use Application
+  use GenServer
 
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+    children = [worker(__MODULE__, [], [name: __MODULE__])]
+    options = [strategy: :one_for_one, name: Edeliver.Supervisor]
+    Supervisor.start_link(children, options)
+  end
+
+
+  def start_link(), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+
+  def run_command([:monitor_startup_progress, application_name = [_|_], :verbose]) do
+    :error_logger.add_report_handler Edeliver.StartupProgress
+    monitor_startup_progress(application_name)
+    :error_logger.delete_report_handler Edeliver.StartupProgress
+  end
+  def run_command([:monitor_startup_progress, application_name = [_|_] | _]) do
+    monitor_startup_progress(application_name)
+  end
   def run_command([command_name, application_name = [_|_] | arguments]) when is_atom(command_name) do
     application_name = to_string(application_name)
     application_name = String.to_atom(to_string(application_name))
     {^application_name, _description, application_version} = :application.which_applications |> List.keyfind(application_name, 0)
     application_version = to_string application_version
     apply __MODULE__, command_name, [application_name, application_version | arguments]
+  end
+
+  @doc """
+    Waits until the edeliver application is started.
+
+    If the edeliver application is added as last application in the `:applications` section of
+    the `application/0` fun in the `mix.exs` this waits until all applications are started.
+    This can be used as rpc call after running the asynchronous `bin/$APP start` command to
+    wait until all applications started and then return `ok`.
+  """
+  @spec monitor_startup_progress(application_name::atom) :: :ok
+  def monitor_startup_progress(application_name) do
+    edeliver_pid = Process.whereis __MODULE__
+    if is_pid(edeliver_pid) do
+      :ok
+    else
+      receive do after 500 -> :ok end
+      monitor_startup_progress(application_name)
+    end
   end
 
   def release_version(application_name, _application_version \\ nil) do

--- a/lib/edeliver/startup_progress.ex
+++ b/lib/edeliver/startup_progress.ex
@@ -1,0 +1,70 @@
+defmodule Edeliver.StartupProgress do
+  @moduledoc """
+    Monitors application start progress.
+
+    This module can be added as additional error report handler
+    using `:error_logger.add_report_handler/1` and
+    handles progress reports from started applications and
+    prints that information on the hidden node that called
+    `Edeliver.monitor_startup_progress/2` as rpc call to
+    wait until the release started after the asynchronous
+    `bin/$APP start` command was executed.
+  """
+
+
+  @typedoc "State / Options passed to this report handler"
+  @type t :: term
+
+  @spec init(t) :: {:ok, t}
+  @doc false
+  def init(state), do: {:ok, state}
+
+  @doc """
+    Handles progress reports from started applications and
+    prints that info on the hidden node that called
+    `Edeliver.monitor_startup_progress/2` as rpc call to
+    wait until the release started after the asynchronous
+    `bin/$APP start` command was executed
+  """
+  # report from different node
+  @spec handle_event({type::atom, pid, term}, t) :: {:ok, t}
+  def handle_event({_type, gl, _message}, state) when node(gl) != node() do
+    {:ok, state}
+  end
+  # progress report
+  def handle_event({:info_report, _pid, {_, :progress, keywords}}, state) do
+    case Keyword.get(keywords, :started_at) do
+      nil -> :ignore
+      _node ->
+        case Keyword.get(keywords, :application) do
+          nil -> :ignore
+          application -> format_in_rpc_script 'Started application \'~w\'.~n', [application]
+        end
+    end
+    {:ok, state}
+  end
+  # no pregress report
+  def handle_event(_event, state), do: {:ok, state}
+
+  @doc false
+  @spec handle_info(term, t) :: {:ok, t}
+  def handle_info(_, state), do: {:ok, state}
+
+  @doc false
+  @spec handle_call(term, t) :: {:error, :bad_query}
+  def handle_call(_query, _state), do: {:error, :bad_query}
+
+  @doc false
+  @spec terminate(atom, t) :: :ok
+  def terminate(_reason, _state), do: :ok
+
+
+  defp format_in_rpc_script(format, arguments) do
+    :erlang.nodes(:hidden) |> Enum.filter(fn node ->
+      Regex.match?(~r/_maint_\d+/, Atom.to_string(node))
+    end) |> Enum.each(fn node ->
+      :rpc.cast(node, :io, :format, [:user, format, arguments])
+    end)
+  end
+
+end

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -801,13 +801,35 @@ force_start_release() {
     [ -f ~/.profile ] && source ~/.profile
     set -e
     cd ${DELIVER_TO}/${APP} $SILENCE
-    ping_result=\$(bin/${APP} ping || :)
-    if [[ \"\$ping_result\" = \"pong\" ]]; then
+    __edeliver_node_running() {
+      bin/${APP} ping 2>/dev/null >/dev/null
+    }
+    __edeliver_synchronous_start() {
+      bin/${APP} start | tail -n+2
+      for i in {1..10}; do
+        __edeliver_node_running && break || :
+        sleep 1
+      done
+      bin/${APP} rpc Elixir.Edeliver run_command '[[monitor_startup_progress, \"$APP\", $MODE]].' | tail -n+2
+    }
+    if __edeliver_node_running; then
       echo \"stopping node\" $SILENCE
-      bin/${APP} stop $SILENCE
+      if [[ \"$RELEASE_CMD\" = \"mix\" ]]; then
+        STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg} | tail -n+2)
+      else
+        STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg})
+      fi
+      if [[ \$? -ne 0 ]]; then
+        cat \"\$STOP_OUTPUT\"
+        exit 1
+      fi
     fi
     echo \"starting node\" $SILENCE
-    bin/${APP} start $SILENCE
+    if [[ \"$RELEASE_CMD\" = \"mix\" ]]; then
+      __edeliver_synchronous_start $SILENCE
+    else
+      ${_node_env}bin/${APP} start ${_config_arg} $SILENCE
+    fi
   "
 }
 

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -810,7 +810,7 @@ force_start_release() {
         __edeliver_node_running && break || :
         sleep 1
       done
-      bin/${APP} rpc Elixir.Edeliver run_command '[[monitor_startup_progress, \"$APP\", $MODE]].' | tail -n+2
+      bin/${APP} rpc Elixir.Edeliver run_command '[[monitor_startup_progress, \"$APP\", $MODE]].' | tail -n+2 | grep -e 'Started\\|^ok' || :
     }
     if __edeliver_node_running; then
       echo \"stopping node\" $SILENCE

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -89,6 +89,7 @@ __deploy_help() {
   echo -e "
 ${bldwht}Usage:${txtrst}
   edeliver deploy release [[to] staging|production] [Options]
+  edeliver deploy upgrade [[to] staging|production] [Options]
 
 ${bldylw}Info:${txtrst}
   Deploys either a release or an upgrade on all staging (default)

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,13 @@ defmodule Edeliver.Mixfile do
     ]
   end
 
+  def application, do:
+    [applications: [],
+     mod: {Edeliver, []},
+     registered: [Edeliver.Supervisor, Edeliver],
+     env: []
+   ]
+
   defp deps, do: [
     {:exrm, ">= 0.16.0"},
     {:meck, "~> 0.8.4", only: :test},

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -148,6 +148,7 @@ __execute_node_command_synchronously() {
     __execute_node_command "single_node" "$_node" "$_node_command"
     echo -e "${txtrst}"
   else
+    echo -n "  response: "
     local _response=$(__execute_node_command "single_node" "$_node" "$_node_command")
     __format_response "$_response"
   fi

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -18,9 +18,9 @@ ${txtbld}Options:${txtrst}
   --host=[u@]vwx.yz Run command only on that host,
                     even if different hosts are configured"
     case "$NODE_ACTION" in
-        (start)    echo -e "\n${bldylw}Info:${txtrst} Starts the node(s) on the deploy hosts.\n" ;;
+        (start)    echo -e "  --verbose Displays progress of started applications\n            if the startup progress takes some time.\n\n${bldylw}Info:${txtrst} Starts the node(s) on the deploy hosts.\n" ;;
         (stop)     echo -e "\n${bldylw}Info:${txtrst} Stops the node(s) on the deploy hosts.\n" ;;
-        (restart)  echo -e "\n${bldylw}Info:${txtrst} Restarts the application on the deploy host(s) with the most recent version.\n" ;;
+        (restart)  echo -e "  --verbose Displays progress of started applications\n            if the startup progress takes some time.\n\n${bldylw}Info:${txtrst} Restarts the application on the deploy host(s) with the most recent version.\n" ;;
         (ping)     echo -e "\n${bldylw}Info:${txtrst} Checks whether the node(s) on the deploy host(s)\n      are running.\n" ;;
         (version)  echo -e "\n${bldylw}Info:${txtrst} Displays the running version(s) on the deploy host(s).\n" ;;
     esac
@@ -142,9 +142,15 @@ __execute_node_command_synchronously() {
   local _node_command=$1
   local _node=${NODES# *}
   __print_node_command_result "single_node" "0" "$_node" ""
-  echo -n "  response: "
-  local _response=$(__execute_node_command "single_node" "$_node" "$_node_command")
-  __format_response "$_response"
+  if [[ "$MODE" = "verbose" ]] &&  [[ "${_node_command}" = start* || "${_node_command}" = restart* ]]; then
+    # display (re)start progress (= started applications)
+    echo -en "  response: ${txtylw}"
+    __execute_node_command "single_node" "$_node" "$_node_command"
+    echo -e "${txtrst}"
+  else
+    local _response=$(__execute_node_command "single_node" "$_node" "$_node_command")
+    __format_response "$_response"
+  fi
 }
 
 # formats the response when node command is executed
@@ -203,21 +209,41 @@ __execute_node_command() {
     [ -f ~/.profile ] && source ~/.profile
     set -e
     cd ${_path}/${APP} $SILENCE
-    if [[ \"${_node_command}\" = restart* ]]; then
+    __edeliver_node_running() {
+      bin/${APP} ping 2>/dev/null >/dev/null
+    }
+    __edeliver_synchronous_start() {
+      bin/${APP} start | tail -n+2
+      for i in {1..10}; do
+        __edeliver_node_running && break || :
+        sleep 1
+      done
+      bin/${APP} rpc Elixir.Edeliver run_command '[[monitor_startup_progress, \"$APP\", $MODE]].' | tail -n+2
+    }
+    if [[ \"$RELEASE_CMD\" = \"mix\" && \"${_node_command}\" = start* ]]; then
+      ping_result=\$(bin/${APP} ping | tail -n+2 || :)
+      if __edeliver_node_running; then
+        echo \"${txtred}already running${txtrst}\" && exit 1
+      else
+        __edeliver_synchronous_start
+      fi
+    elif [[ \"${_node_command}\" = restart* ]]; then
       # use stop / start instead of restart command to
       # not just restart the applications but also the erlang vm
       # with the most recent release
-      if [[ \"$RELEASE_CMD\" = \"mix\" ]]; then
-        STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg} | tail -n+2)
-      else
-        STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg})
+      if __edeliver_node_running; then
+        if [[ \"$RELEASE_CMD\" = \"mix\" ]]; then
+          STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg} | tail -n+2)
+        else
+          STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg})
+        fi
+        if [[ \$? -ne 0 ]]; then
+          cat \"\$STOP_OUTPUT\"
+          exit 1
+        fi
       fi
-      if [[ \$? -ne 0 ]]; then
-        cat \"\$STOP_OUTPUT\"
-        exit 1
-      fi
       if [[ \"$RELEASE_CMD\" = \"mix\" ]]; then
-        ${_node_env}bin/${APP} start ${_config_arg} | tail -n+2
+        __edeliver_synchronous_start
       else
         ${_node_env}bin/${APP} start ${_config_arg}
       fi

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -219,7 +219,7 @@ __execute_node_command() {
         __edeliver_node_running && break || :
         sleep 1
       done
-      bin/${APP} rpc Elixir.Edeliver run_command '[[monitor_startup_progress, \"$APP\", $MODE]].' | tail -n+2
+      bin/${APP} rpc Elixir.Edeliver run_command '[[monitor_startup_progress, \"$APP\", $MODE]].' | tail -n+2 | grep -e 'Started\\|^ok' || :
     }
     if [[ \"$RELEASE_CMD\" = \"mix\" && \"${_node_command}\" = start* ]]; then
       ping_result=\$(bin/${APP} ping | tail -n+2 || :)


### PR DESCRIPTION
Wait until all apps are started for the (re)start command and display progress of started applications if the `--verbose` option is used.