### PR TITLE
Use exrm as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ It can be used with any one of these build systems:
 
 Edeliver tries to autodetect which system to use:
 
-  * If a `./mix.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [exrm](https://github.com/bitwalker/exrm) is used to generate the releases / upgrades.
   * If a `./mix.exs` and a `rel/config.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [distillery](https://github.com/bitwalker/distillery) is used to generate the releases / upgrades.
+  * If a `./mix.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [exrm](https://github.com/bitwalker/exrm) is used to generate the releases / upgrades.
   * If a `./relx.config` file exists in addition to a `./mix.exs` file, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [relx](https://github.com/erlware/relx) is used to generate the releases / upgrades.
   * Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades.
 

--- a/README.md
+++ b/README.md
@@ -165,13 +165,6 @@ def application, do: [
 ]
 ```
 
-Before using mix to build the releases, you should install [hex](https://hex.pm) on the build host before the first build (otherwise mix asks interactively to install it).
-
-```console
-mix local.hex
-```
-
-
 ### Rebar considerations
 
 When using rebar, edeliver can be added as [rebar](https://github.com/basho/rebar) depencency. Just add it to your `rebar.config` (and ensure that a `./rebar` binary/link is in your project directory):

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Once built, the [release](http://www.erlang.org/doc/design_principles/release_ha
 
 Assuming an Elixir project, you already have a build server and a staging server, and you've created a database on your staging server already (there is no ecto.create, we skip straight to migrations).
 
-Add edeliver to your project dependencies in mix.exs:
+Add edeliver and your build tool ([distillery](https://github.com/bitwalker/distillery) or [exrm](https://github.com/bitwalker/exrm)) to your project dependencies in mix.exs:
 
 ```exs
 def application, do: [
   applications: [
+  	 ...
     # Add edeliver to the END of the list
     :edeliver
   ]
@@ -51,7 +52,9 @@ def application, do: [
 defp deps do
   [
     ...
-    {:edeliver, "~> 1.3.0"}
+    {:edeliver, "~> 1.3.0"},
+    {:distillery, ">= 0.8.0", warn_missing: false},
+    # or :exrm
   ]
 end
 ```
@@ -112,8 +115,8 @@ Because it is based on [deliver](https://github.com/gerhard/deliver), is uses on
 
 It can be used with any one of these build systems:
 
+  * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [distillery](https://github.com/bitwalker/distillery) for elixir/erlang releases (recommended)
   * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [exrm](https://github.com/bitwalker/exrm) for elixir/erlang releases
-  * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [distillery](https://github.com/bitwalker/distillery) for elixir/erlang releases
   * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [relx](https://github.com/erlware/relx) for elixir/erlang releases
   * [rebar](https://github.com/basho/rebar) for pure erlang releases
 
@@ -137,11 +140,15 @@ The Erlang runtime (OTP) and the Elixir runtime are packaged with the release—
 
 ### Mix considerations
 
-If using [mix](http://elixir-lang.org/getting_started/mix/1.html), add edeliver as [hex package](https://hex.pm/packages/edeliver) to your `mix.exs` config:
+If using [mix](http://elixir-lang.org/getting_started/mix/1.html), add edeliver and your build tool and your build tool ([distillery](https://hex.pm/packages/distillery) or [exrm](https://hex.pm/packages/exrm)) as [hex package](https://hex.pm/packages/edeliver) to your `mix.exs` config:
 
 ```exs
 defp deps do
-  [{:edeliver, ">= 1.3.0"}]
+  [
+  	{:edeliver, ">= 1.3.0"},
+    {:distillery, ">= 0.8.0", warn_missing: false},
+	# or {:exrm, ">= 0.16.0", warn_missing: false},
+  ]
 end
 ```
 

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -44,7 +44,6 @@ defmodule Releases.Plugin.LinkConfig do
         tar_file = Path.join [output_dir, "releases", version, "#{name}.tar.gz"]
         true = File.exists? tar_file
         :ok = File.mkdir_p tmp_path
-        tar_binary = <<_,_::binary>> = System.find_executable "tar"
         ln_binary = <<_,_::binary>>  = System.find_executable "ln"
         debug "Extracting release tar to #{tmp_dir}"
         :ok = :erl_tar.extract(tar_file, [{:cwd, to_char_list(tmp_path)}, :compressed])

--- a/mix.exs
+++ b/mix.exs
@@ -34,18 +34,9 @@ defmodule Edeliver.Mixfile do
    ]
 
   defp deps do
-    if project_uses_distillery? do
-      [
-        {:distillery, ">= 0.8.0", warn_missing: false},
-        {:exrm, ">= 0.16.0", optional: true, warn_missing: false},
-      ]
-    else
-      [
-        {:exrm, ">= 0.16.0", warn_missing: false},
-        {:distillery, ">= 0.8.0", optional: true, warn_missing: false},
-      ]
-    end ++
     [
+      {:distillery, ">= 0.8.0", optional: true, warn_missing: false},
+      {:exrm, ">= 0.16.0", optional: true, warn_missing: false},
       {:meck, "~> 0.8.4", only: :test},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.11.5", only: :dev},

--- a/strategies/publish-edeliver
+++ b/strategies/publish-edeliver
@@ -67,8 +67,8 @@ update_version() {
   sed -i -e "s/DELIVER_VERSION\s*=\s*\"[^\"]\{1,\}\"/DELIVER_VERSION=\"$_new_version\"/" "${BASE_PATH}/libexec/defaults" # | grep DELIVER_VER
   # ./README.md:56:        {:edeliver, "~> $_current_version"}
   sed -i -e "s/^\([[:space:]]*{:edeliver,[[:space:]]*\"[[:space:]]*~>\)[^\"]\{1,\}\"/\1 $_new_version\"/" "${BASE_PATH}/README.md" # | grep '{:edeliver'
-  # ./README.md:144:        [{:edeliver, ">= $_current_version"}]
-  sed -i -e "s/^\([[:space:]]*\[{:edeliver,[[:space:]]*\"[[:space:]]*>=\)[^\"]\{1,\}\"/\1 $_new_version\"/" "${BASE_PATH}/README.md" # | grep '\[{:edeliver'
+  # ./README.md:144:        {:edeliver, ">= $_current_version"}
+  sed -i -e "s/^\([[:space:]]*{:edeliver,[[:space:]]*\"[[:space:]]*>=\)[^\"]\{1,\}\"/\1 $_new_version\"/" "${BASE_PATH}/README.md" # | grep '\[{:edeliver'
   # README.md:82:      {edeliver, "1.0",
   sed -i -e "s/^\([[:space:]]*{edeliver,[[:space:]]*\"\)[^\"]\{1,\}\"/\1$_new_version\"/" "${BASE_PATH}/README.md" # | grep '{edeliver'
   # mix.exs:7:      version: "1.1.5",


### PR DESCRIPTION
to be able to use distillery as build tool. This requires to add `exrm` as dependency to all new projects using edeliver and exrm as build tool. See #132