### PR TITLE
Build deps explicitly for mix version `1.3.[0123]`

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -166,10 +166,10 @@ erlang_clean_compile() {
       [[ \"$SKIP_MIX_CLEAN\" != \"true\" ]] && $REBAR_CMD clean skip_deps=true || :
       $REBAR_CMD compile
     elif [ \"$BUILD_CMD\" = \"mix\" ] && [ \"$RELEASE_CMD\" = \"mix\" ]; then
-      echo \"Checking whether deps must be compiled for mix version 1.3.0\"
+      echo \"Checking whether deps must be compiled for mix version 1.3.[0123]\"
       # see https://github.com/boldpoker/edeliver/issues/94
-      if $MIX_CMD --version | grep 'Mix 1.3.0' >/dev/null 2>&1 ; then
-        echo \"Compiling deps because mix version 1.3.0 is used\"
+      if $MIX_CMD --version | grep 'Mix 1.3.[0123]' >/dev/null 2>&1 ; then
+        echo \"Compiling deps because mix version 1.3.[0123] is used\"
         APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD deps.compile
       fi
       if [[ \"$SKIP_MIX_CLEAN\" = \"true\" ]]; then


### PR DESCRIPTION
This expands the existing workaround to include the additional mix versions that contain the issue. It appears that Elixir 1.3.4 will contain the mix compilation fix. https://github.com/elixir-lang/elixir/issues/5094#issuecomment-252489258