### PR TITLE
Fix deployment using mix releases

### DIFF
--- a/docker/start_container
+++ b/docker/start_container
@@ -170,8 +170,10 @@ DOCKER_OPTS+=" --env RELEASE_DISTRIBUTION=${RELEASE_DISTRIBUTION}"
 DOCKER_OPTS+=" --env RELEASE_NODE=${RELEASE_NODE}"
 
 
-if [ "$COMMAND" = "start" ] || [ "$COMMAND" = "daemon" ]; then
+if [ "$COMMAND" = "daemon" ]; then
   DOCKER_OPTS+=" --detach --tty"
+elif [ "$COMMAND" = "start" ] && [ "$RELEASE_CMD" != "mix" ]; then
+  DOCKER_OPTS+=" --detach --tty"  
 elif [ -t 0 ]; then # terminal attatched
   DOCKER_OPTS+=" --tty --interactive" 
 fi

--- a/libexec/app_config
+++ b/libexec/app_config
@@ -111,6 +111,6 @@ if [ -z "$RELEASE_CMD" ]; then
 fi
 
 if [ "$RELEASE_CMD" = "mix" ]; then
-    [[ -f "./rel/config.exs" ]] && USING_DISTILLERY="true"
+    [[ -f "./rel/config.exs" ]] && USING_DISTILLERY="${USING_DISTILLERY:-true}"
 fi
 

--- a/libexec/app_config
+++ b/libexec/app_config
@@ -111,6 +111,6 @@ if [ -z "$RELEASE_CMD" ]; then
 fi
 
 if [ "$RELEASE_CMD" = "mix" ]; then
-    [[ -f "./rel/config.exs" ]] && USING_DISTILLERY="${USING_DISTILLERY:-true}"
+    [[ -f "./rel/config.exs" ]] && USING_DISTILLERY="${USING_DISTILLERY:-true}" || USING_DISTILLERY="${USING_DISTILLERY:-false}"
 fi
 

--- a/libexec/app_config
+++ b/libexec/app_config
@@ -21,7 +21,7 @@ fi
 #
 if [ -z "$DELIVER_TO" ]
 then
-  DELIVER_TO="~$APP_USER/app"
+  DELIVER_TO="~/apps"
 fi
 
 if [ -z "$GIT_PUSH" ]

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1156,9 +1156,9 @@ __get_node_command() {
       set -e
       cd ${_app_path}/${APP} $SILENCE
       if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$USING_DISTILLERY\" = \"false\" ]; then
-        output_lines=\"\$(bin/${APP} pid | wc -l | tr -d ' ')\"
+        output_lines=\"\$(bin/${APP} pid 2>/dev/null | wc -l | tr -d ' ')\"
       else
-        output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
+        output_lines=\"\$(bin/${APP} ping 2>/dev/null | wc -l | tr -d ' ')\"
       fi
       if [ \"\$output_lines\" -gt 1 ]; then
         output_filter_command='tail'

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1164,12 +1164,8 @@ __get_node_command() {
         output_filter_command_options=''
       fi
       __edeliver_node_running() {
-        if [ \"$RELEASE_CMD\" = \"mix\" ]; then
-          if [ \"$USING_DISTILLERY\" = \"true\" ]; then
-            bin/${APP} pid 2>/dev/null >/dev/null
-          else 
-            bin/${APP} ping 2>/dev/null >/dev/null
-          fi
+        if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$USING_DISTILLERY\" = \"false\" ]; then
+          bin/${APP} pid 2>/dev/null >/dev/null
         else
           bin/${APP} ping 2>/dev/null >/dev/null
         fi

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1155,7 +1155,11 @@ __get_node_command() {
       [ -f \"$PROFILE\" ] && . \"$PROFILE\"
       set -e
       cd ${_app_path}/${APP} $SILENCE
-      output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
+      if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$USING_DISTILLERY\" = \"false\" ]; then
+        output_lines=\"\$(bin/${APP} pid | wc -l | tr -d ' ')\"
+      else
+        output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
+      fi
       if [ \"\$output_lines\" -gt 1 ]; then
         output_filter_command='tail'
         output_filter_command_options=\"-n+\$output_lines\"

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1176,7 +1176,6 @@ __get_node_command() {
         bin/${APP} ${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:monitor_startup_progress, \"$APP\", :$MODE${_rpc_close_brackets})' | \$output_filter_command \$output_filter_command_options | grep -e 'Started\\|^ok' || :
       }
       if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$_is_start_command\" = \"true\" ]; then
-        ping_result=\"\$(bin/${APP} ping | \$output_filter_command \$output_filter_command_options || :)\"
         if __edeliver_node_running; then
           echo \"${txtred}already running${txtrst}\" && exit 1
         else

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1258,7 +1258,7 @@ remote_extract_release_archive() {
         echo \"Extracted script\"
       } || {
         echo \"Copied edeliver default script\"
-        echo \"${bldylw}Using edeliver default script.\nPlease consider to add your own version at $CONTAINER_START_SCRIPT.\n${txtrst}\" >&2
+        echo -e \"${bldylw}Using edeliver default script.\nPlease consider to add your own version at $CONTAINER_START_SCRIPT.\n${txtrst}\" >&2
         cat >\"$APP\"
       }
       chmod 700 \"$APP\"

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1164,7 +1164,15 @@ __get_node_command() {
         output_filter_command_options=''
       fi
       __edeliver_node_running() {
-        bin/${APP} ping 2>/dev/null >/dev/null
+        if [ \"$RELEASE_CMD\" = \"mix\" ]; then
+          if [ \"$USING_DISTILLERY\" = \"true\" ]; then
+            bin/${APP} pid 2>/dev/null >/dev/null
+          else 
+            bin/${APP} ping 2>/dev/null >/dev/null
+          fi
+        else
+          bin/${APP} ping 2>/dev/null >/dev/null
+        fi
       }
       __edeliver_synchronous_start() {
         bin/${APP} start | \$output_filter_command \$output_filter_command_options

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1185,6 +1185,8 @@ __get_node_command() {
         else
           __edeliver_synchronous_start
         fi
+      elif [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$USING_DISTILLERY\" = \"false\" ] && [ \"${_node_command}\" = \"ping\" ]; then
+        __edeliver_node_running && echo pong || echo 'Node is not running!'
       elif [ \"$_is_restart_command\" = \"true\" ]; then
         # use stop / start instead of restart command to
         # not just restart the applications but also the erlang vm

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1142,7 +1142,7 @@ __get_node_command() {
   if declare -F "get_${_node_command}_node_command" > /dev/null; then
     eval "get_${_node_command}_node_command $@"
   else
-    if [[ "$USING_DISTILLERY" = "true" ]]; then
+    if [[ "$RELEASE_CMD" = "mix" ]]; then
       local _rpc_open_brackets="["
       local _rpc_close_brackets="]"
     else
@@ -1181,7 +1181,7 @@ __get_node_command() {
           __edeliver_node_running && break || :
           sleep 1
         done
-        bin/${APP} ${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:monitor_startup_progress, \"$APP\", :$MODE${_rpc_close_brackets})' | \$output_filter_command \$output_filter_command_options | grep -e 'Started\\|^ok' || :
+        bin/${APP} ${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:monitor_startup_progress,\"$APP\",:$MODE${_rpc_close_brackets})' | \$output_filter_command \$output_filter_command_options | grep -e 'Started\\|^ok' || :
       }
       if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$_is_start_command\" = \"true\" ]; then
         if __edeliver_node_running; then


### PR DESCRIPTION
Releases built with the builtin `mix release` task (and not with distillery) don't support a `ping` command. Using `pid` command instead which also returns `0` as status code when running and `1` otherwise.

Fixes #364.