### PR TITLE
Set host name which is not too long in github action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
 
     - name: Preparing Local Deploy
       run: |
+        sudo hostnamectl set-hostname rebar3.edeliver.test
         mkdir -p /home/runner/.ssh/ && touch /home/runner/.ssh/known_hosts
         echo "internal_ip=$(hostname -I | cut -d' ' -f1)" >> $GITHUB_ENV
     - name: Deploying Image Locally
@@ -60,6 +61,7 @@ jobs:
       run: test/docker/build-distillery.sh
     - name: Preparing Local Deploy
       run: |
+        sudo hostnamectl set-hostname distillery.edeliver.test
         mkdir -p /home/runner/.ssh/ && touch /home/runner/.ssh/known_hosts
         echo "internal_ip=$(hostname -I | cut -d' ' -f1)" >> $GITHUB_ENV
     - name: Deploying Image Locally
@@ -98,6 +100,7 @@ jobs:
 
     - name: Preparing Local Deploy
       run: |
+        sudo hostnamectl set-hostname mix.edeliver.test
         mkdir -p /home/runner/.ssh/ && touch /home/runner/.ssh/known_hosts
         echo "internal_ip=$(hostname -I | cut -d' ' -f1)" >> $GITHUB_ENV
     - name: Deploying Image Locally


### PR DESCRIPTION
because hostnames generated by docker hub can be longer than 63 characters which causes docker containers to fail
on start with:

```
Using tag 0.1.0-1bef713 of image edeliver/echo-server-distillery

  Using hostname fv-az135-227.uqcy5m2vj4pengxy1oencsd1xf.phxx.internal.cloudapp.net
  Using container name eco

61bf85f804568d3b26bf8abdc740e9b33bed0cd302d2902ab419d23a1eb89a22

docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: sethostname: invalid argument: unknown.
```

```sh
echo -n "fv-az135-227.uqcy5m2vj4pengxy1oencsd1xf.phxx.internal.cloudapp.net" | wc -c
66
```