### PR TITLE
Docker deploy improvements

### DIFF
--- a/libexec/core
+++ b/libexec/core
@@ -298,9 +298,21 @@ __remote() {
 
   __log "${_hosts} : $_remote_job"
 
+  if [ -t 0 ]; then 
+    local _in_a_pipe="false"
+  else 
+    local _in_a_pipe="true"
+    local _piped_data="$(</dev/stdin)"
+  fi
+
   for _host in $_hosts
   do
-    ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "$_remote_job $SILENCE" &
+    if [ "$_in_a_pipe" = "true" ]; then
+      echo -n "$_piped_data" | ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "$_remote_job $SILENCE" &
+    else
+      ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "$_remote_job $SILENCE" &
+    fi
+
     background_jobs_pids+=("$!")
     local _background_job="ssh -o ConnectTimeout=$SSH_TIMEOUT $_host $_remote_job $SILENCE"
     background_jobs+=("ssh -o ConnectTimeout=$SSH_TIMEOUT $_host $_error_info_for_remote_job $SILENCE")

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1201,27 +1201,7 @@ remote_extract_release_archive() {
       info "Configure mounting of vm args from $LINK_VM_ARGS to ${_vm_args_dest}"
       DOCKER_OPTS+=" --mount type=bind,source="${LINK_VM_ARGS}",target=${_vm_args_dest}"
     fi
-    # read which release command was used from the docker image lables because
-    # releases built with rebar3 needs a different ERL_DIST_PORT set when starting the remote console
-    # as releases built with distillery. For distillery it needs to be a random port (0) while
-    # for rebar3 it needs to be the port the actual server listens on.
-    _release_command="$(docker inspect --format '{{ index .Config.Labels "edeliver.release.command"}}' "${_image_name}")"
-    # if release command was not found in image labels, fall back to edeliver configuration if available
-    if [[ -z "${_release_command// }" ]]; then
-      _release_command="$RELEASE_CMD"
-      if [ "$_release_command" = "mix" ]; then
-        if ! [ "$USING_DISTILLERY" = "false" ]; then
-          _release_command="distillery"
-        fi
-      fi
-    fi
-    cat "${BASE_PATH}/docker/start_container" \
-      | sed "s/{{edeliver-version}}/${_release_version}/g" \
-      | sed "s\${{edeliver-docker-image}}\$${DOCKER_RUN_IMAGE}\$g" \
-      | sed "s\${{edeliver-docker-opts}}\$${DOCKER_OPTS}\$g" \
-      | sed "s\${{edeliver-release-command}}\$${_release_command}\$g" \
-      | sed "s/{{edeliver-app}}/${APP}/g" \
-      | __remote "
+    cat "${BASE_PATH}/docker/start_container" | __remote "
       if [ \"\$0\" = \"/bin/sh\" ]; then
         [ -f $PROFILE ] && . $PROFILE
         set -e
@@ -1232,11 +1212,6 @@ remote_extract_release_archive() {
       mkdir -p \"${_archive_dir}\"
       cd \"${_archive_dir}\" $SILENCE
       docker run --rm \"${_image_name}\" cat \"$CONTAINER_START_SCRIPT\" 2>/dev/null \
-         | sed \"s/{{edeliver-version}}/${_release_version}/g\" \
-         | sed \"s\\\${{edeliver-docker-image}}\\\$${DOCKER_RUN_IMAGE}\\\$g\" \
-         | sed \"s\\\${{edeliver-docker-opts}}\\\$${DOCKER_OPTS}\\\$g\" \
-         | sed \"s\\\${{edeliver-release-command}}\\\$${_release_command}\\\$g\" \
-         | sed \"s/{{edeliver-app}}/${APP}/g\" \
          > \"$APP\" && [ -s \"$APP\" ] && { # set -o pipefail is not avialble on non-bash shells, so file might be empty
         echo \"Extracted script\"
       } || {
@@ -1245,7 +1220,26 @@ remote_extract_release_archive() {
         cat >\"$APP\"
       }
       chmod 700 \"$APP\"
-    " || error "Failed to extract remote start script!"
+      # read which release command was used from the docker image lables because
+      # releases built with rebar3 needs a different ERL_DIST_PORT set when starting the remote console
+      # as releases built with distillery. For distillery it needs to be a random port (0) while
+      # for rebar3 it needs to be the port the actual server listens on.
+      _release_command=\"\$(docker inspect --format '{{ index .Config.Labels \"edeliver.release.command\"}}' \"${_image_name}\")\"
+      # if release command was not found in image labels, fall back to edeliver configuration if available
+      if [[ -z \"${_release_command// }\" ]]; then
+        _release_command=\"$RELEASE_CMD\"
+        if [ \"$_release_command\" = \"mix\" ]; then
+          if ! [ \"$USING_DISTILLERY\" = \"false\" ]; then
+            _release_command=\"distillery\"
+          fi
+        fi
+      fi
+      sed -i \"s/{{edeliver-version}}/${_release_version}/g\" \"$APP\"
+      sed -i \"s\\\${{edeliver-docker-image}}\\\$${DOCKER_RUN_IMAGE}\\\$g\" \"$APP\"
+      sed -i \"s\\\${{edeliver-docker-opts}}\\\$${DOCKER_OPTS}\\\$g\" \"$APP\"
+      sed -i \"s\\\${{edeliver-release-command}}\\\$${_release_command}\\\$g\" \"$APP\"
+      sed -i \"s/{{edeliver-app}}/${APP}/g\" \"$APP\"
+    " || error "Failed to install remote start script!"
   else
     status "Extracting archive ${_archive} into ${_archive_dir}"
     # when building releases with mix, the tar does not contain the app name as subdirectory

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1241,9 +1241,9 @@ remote_extract_release_archive() {
       # releases built with rebar3 needs a different ERL_DIST_PORT set when starting the remote console
       # as releases built with distillery. For distillery it needs to be a random port (0) while
       # for rebar3 it needs to be the port the actual server listens on.
-      _release_command=\"\$(docker inspect --format '{{ index .Config.Labels \"edeliver.release.command\"}}' \"${_image_name}\")\"
+      _release_command=\"\$(docker inspect --format '{{ index .Config.Labels \"edeliver.release.command\"}}' \"${_image_name}\" | tr -d '[:space:]')\"
       # if release command was not found in image labels, fall back to edeliver configuration if available
-      if [ -z \"\${_release_command// }\" ]; then
+      if [ -z \"\$_release_command\" ]; then
         _release_command=\"$RELEASE_CMD\"
         if [ \"\$_release_command\" = \"mix\" ]; then
           if ! [ \"$USING_DISTILLERY\" = \"false\" ]; then

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -903,7 +903,22 @@ __get_releases_in_store() {
           echo "You can also set DOCKER_HUB_ACCESS_TOKEN to generate DOCKER_REGISTRY_TOKEN automatically." >&2
         fi
       fi
-      exit 2
+      local _found_local_tags="false"
+      for tag in $(docker image ls --format "{{.Tag}}" "${DOCKER_RUN_IMAGE}"); do
+        if [ -z "$selected_tag" ]; then
+          selected_tag="$tag"
+        fi
+        if [ "$tag" != "<none>" ] && [[ -z "$max_images" || $i -lt "$max_images" ]]; then
+          echo "$tag"
+          _found_local_tags="true"
+          i=$(( i+1 ))
+        fi
+      done
+      if [ "$_found_local_tags" = "true" ]; then
+        echo "Using local tags from local docker registry." >&2
+      else
+        exit 2
+      fi
     else
       local _image_info _tag _created_at
       # e.g. for google container registry containing detaild information about tags and their timestamps:

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1243,9 +1243,9 @@ remote_extract_release_archive() {
       # for rebar3 it needs to be the port the actual server listens on.
       _release_command=\"\$(docker inspect --format '{{ index .Config.Labels \"edeliver.release.command\"}}' \"${_image_name}\")\"
       # if release command was not found in image labels, fall back to edeliver configuration if available
-      if [ -z \"${_release_command// }\" ]; then
+      if [ -z \"\${_release_command// }\" ]; then
         _release_command=\"$RELEASE_CMD\"
-        if [ \"$_release_command\" = \"mix\" ]; then
+        if [ \"\$_release_command\" = \"mix\" ]; then
           if ! [ \"$USING_DISTILLERY\" = \"false\" ]; then
             _release_command=\"distillery\"
           fi
@@ -1254,7 +1254,7 @@ remote_extract_release_archive() {
       sed -i \"s/{{edeliver-version}}/${_release_version}/g\" \"$APP\"
       sed -i \"s\\\${{edeliver-docker-image}}\\\$${DOCKER_RUN_IMAGE}\\\$g\" \"$APP\"
       sed -i \"s\\\${{edeliver-docker-opts}}\\\$${DOCKER_OPTS}\\\$g\" \"$APP\"
-      sed -i \"s\\\${{edeliver-release-command}}\\\$${_release_command}\\\$g\" \"$APP\"
+      sed -i \"s\\\${{edeliver-release-command}}\\\$\${_release_command}\\\$g\" \"$APP\"
       sed -i \"s/{{edeliver-app}}/${APP}/g\" \"$APP\"
     " || error "Failed to install remote start script!"
   else

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -908,10 +908,12 @@ __get_releases_in_store() {
         if [ -z "$selected_tag" ]; then
           selected_tag="$tag"
         fi
-        if [ "$tag" != "<none>" ] && [[ -z "$max_images" || $i -lt "$max_images" ]]; then
-          echo "$tag"
-          _found_local_tags="true"
-          i=$(( i+1 ))
+        if [ "$tag" != "<none>" ]; then
+          if [ -z "$max_images" ] || [ $i -lt "$max_images" ]; then
+            echo "$tag"
+            _found_local_tags="true"
+            i=$(( i+1 ))
+          fi
         fi
       done
       if [ "$_found_local_tags" = "true" ]; then
@@ -1241,7 +1243,7 @@ remote_extract_release_archive() {
       # for rebar3 it needs to be the port the actual server listens on.
       _release_command=\"\$(docker inspect --format '{{ index .Config.Labels \"edeliver.release.command\"}}' \"${_image_name}\")\"
       # if release command was not found in image labels, fall back to edeliver configuration if available
-      if [[ -z \"${_release_command// }\" ]]; then
+      if [ -z \"${_release_command// }\" ]; then
         _release_command=\"$RELEASE_CMD\"
         if [ \"$_release_command\" = \"mix\" ]; then
           if ! [ \"$USING_DISTILLERY\" = \"false\" ]; then

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1030,19 +1030,44 @@ EOF
       error "Uploading release file failed\n  source: ${_release_store_path%%/}/${_release_file} on $_release_store_host\n  destination: $_dest_file_name on deploy hosts"
   elif [ "$RELEASE_STORE_TYPE" = "docker" ]; then
     local _image_name="${DOCKER_RUN_IMAGE}:${_release_version}"
-    __remote "
-      [ -f $PROFILE ] && . $PROFILE
-      set -e
-      mkdir -p ${_destination_directory} $SILENCE
-      cd ${_destination_directory} $SILENCE
-      if [ -z \"\$(docker images -q \"$_image_name\")\" ]; then
-        echo \"Pulling release image $_image_name\" $SILENCE
-        docker pull \"$_image_name\" $SILENCE || {
-          echo \"Failed to pull release image $_image_name\" >&2
-          exit 1
-        }
+    if [ "$DOCKER_PUSH" = "true" ]; then
+      # push from local docker registry on local host to local docker registry
+      # on deploy hosts using docker save / load
+      if [ "$VERBOSE" = "true" ]; then
+        echo "Pushing release image $_image_name from local docker registry"
       fi
-    "
+      __docker save "$_image_name" | gzip -c - | base64 | __remote "
+        [ -f $PROFILE ] && . $PROFILE
+        set -e
+        mkdir -p ${_destination_directory} $SILENCE
+        cd ${_destination_directory} $SILENCE
+        if [ -z \"\$(docker images -q \"$_image_name\")\" ]; then
+          echo \"Loading release image $_image_name into local registry\" $SILENCE
+          base64 -d | gzip -d | docker load $SILENCE
+          if [ -z \"\$(docker images -q \"$_image_name\")\" ]; then
+            echo \"Failed to push release image $_image_name\" >&2
+            exit 1
+          fi
+        fi
+      " || error "Failed to push image from local docker registry to docker registry on deploy host"
+    else
+      __remote "
+        [ -f $PROFILE ] && . $PROFILE
+        set -e
+        mkdir -p ${_destination_directory} $SILENCE
+        cd ${_destination_directory} $SILENCE
+        if [ -z \"\$(docker images -q \"$_image_name\")\" ]; then
+          echo \"Pulling release image $_image_name\" $SILENCE
+          docker pull \"$_image_name\" $SILENCE || {
+            echo \"Failed to pull release image $_image_name\" >&2
+            if [ \"$DOCKER_PUSH\" != \"true\" ]; then
+              echo -e \"\nUse --push flag to push $_image_name \nfrom your local docker registry to the deploy host(s)\" >&2
+            fi
+            exit 1
+          }
+        fi
+      "
+    fi
   else
     error_message "Cannot upload release for store type ${RELEASE_STORE_TYPE}"; exit 2
   fi

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -45,6 +45,7 @@ __help() {
   -S, --skip-existing   Skip copying release archives if they exist already on the deploy hosts.
   -F, --force           Do not ask, just do, overwrite, delete or destroy everything
       --push            Pushes the docker image after successful build if release store is a registry
+                        or \"pushes\" the image from the local registry to the deploy host(s) on deploy
       --clean-deploy    Delete the release, lib and erts-* directories before deploying the release
       --skip-git-clean  Don't build from a clean state for faster builds. See $GIT_CLEAN_PATHS env
       --skip-mix-clean  Skip the 'mix clean step' for faster builds. Use in addition to --skip-git-clean


### PR DESCRIPTION
This includes:

- [x] pipe data remotely to all hosts
- [x] allow to deploy without remote docker registry using `--push` on deploy
- [x] detect release tool type on deploy host to fix installing CI builds  