### PR TITLE
Fix migration commands

### DIFF
--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -83,10 +83,8 @@ run() {
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
     local __up_or_down="up"
     for arg in $ARGS; do [[ "$arg" = "down" ]] && local __up_or_down="down"; done
-    [[ -n "$VERSION" ]] && local __to_version=", \"$VERSION\"" || local __to_version=""
-    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate, \"$APP\", \"$ECTO_REPOSITORY\", :${__up_or_down}${__to_version}${_rpc_close_brackets})'"
-    #     [[ -n "$VERSION" ]] && local __to_version=",\"$VERSION\"" || local __to_version=""
-    # NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate,\"$APP\",\"$ECTO_REPOSITORY\",:${__up_or_down}${__to_version}${_rpc_close_brackets})'"
+    [[ -n "$VERSION" ]] && local __to_version=",\"$VERSION\"" || local __to_version=""
+    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate,\"$APP\",\"$ECTO_REPOSITORY\",:${__up_or_down}${__to_version}${_rpc_close_brackets})'"
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" != "mix" ]]; then
     error "Executing migrations is only supported when using mix as release command."
   elif [[ "$RELEASE_CMD" = "mix" ]]; then

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -73,11 +73,11 @@ run() {
   fi
 
   if [[ "$NODE_ACTION" = version ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
-    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:release_version, \"$APP\"${_rpc_close_brackets})' | tr -d \\\""
+    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:release_version,\"$APP\"${_rpc_close_brackets})' | tr -d \\\""
   elif [[ "$NODE_ACTION" = ping ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
     NODE_ACTION="ping"
   elif [[ "$NODE_ACTION" = migrations ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
-    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:list_pending_migrations, \"$APP\", \"$ECTO_REPOSITORY\"${_rpc_close_brackets})'"
+    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:list_pending_migrations,\"$APP\",\"$ECTO_REPOSITORY\"${_rpc_close_brackets})'"
   elif [[ "$NODE_ACTION" = migrations ]] && [[ "$RELEASE_CMD" != "mix" ]]; then
     error "Showing migrations is only supported when using mix as release command."
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" = "mix" ]]; then

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -84,7 +84,7 @@ run() {
     local __up_or_down="up"
     for arg in $ARGS; do [[ "$arg" = "down" ]] && local __up_or_down="down"; done
     [[ -n "$VERSION" ]] && local __to_version=", \"$VERSION\"" || local __to_version=""
-    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate, \"$APP\", \"$ECTO_REPOSITORY\", :${__up_or_down}, ${__to_version}${_rpc_close_brackets})'"
+    NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate, \"$APP\", \"$ECTO_REPOSITORY\", :${__up_or_down}${__to_version}${_rpc_close_brackets})'"
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" != "mix" ]]; then
     error "Executing migrations is only supported when using mix as release command."
   elif [[ "$RELEASE_CMD" = "mix" ]]; then

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -64,7 +64,7 @@ run() {
   [[ "$NODE_ACTION" = version ]] && status "getting release versions from $NODE_ENVIRONMENT servers" || status "${NODE_ACTION}ing $NODE_ENVIRONMENT servers"
   authorize_hosts
   local _rpc_command="rpc"
-  if [[ "$USING_DISTILLERY" = "true" ]]; then
+  if [[ "$USING_DISTILLERY" = "true" || "$RELEASE_CMD" = "mix"; ]]; then
     local _rpc_open_brackets="["
     local _rpc_close_brackets="]"
   else
@@ -85,6 +85,8 @@ run() {
     for arg in $ARGS; do [[ "$arg" = "down" ]] && local __up_or_down="down"; done
     [[ -n "$VERSION" ]] && local __to_version=", \"$VERSION\"" || local __to_version=""
     NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate, \"$APP\", \"$ECTO_REPOSITORY\", :${__up_or_down}${__to_version}${_rpc_close_brackets})'"
+    #     [[ -n "$VERSION" ]] && local __to_version=",\"$VERSION\"" || local __to_version=""
+    # NODE_ACTION="${_rpc_command} 'Elixir.Edeliver.run_command(${_rpc_open_brackets}:migrate,\"$APP\",\"$ECTO_REPOSITORY\",:${__up_or_down}${__to_version}${_rpc_close_brackets})'"
   elif [[ "$NODE_ACTION" = migrate ]] && [[ "$RELEASE_CMD" != "mix" ]]; then
     error "Executing migrations is only supported when using mix as release command."
   elif [[ "$RELEASE_CMD" = "mix" ]]; then

--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -64,7 +64,7 @@ run() {
   [[ "$NODE_ACTION" = version ]] && status "getting release versions from $NODE_ENVIRONMENT servers" || status "${NODE_ACTION}ing $NODE_ENVIRONMENT servers"
   authorize_hosts
   local _rpc_command="rpc"
-  if [[ "$USING_DISTILLERY" = "true" || "$RELEASE_CMD" = "mix"; ]]; then
+  if [[ "$USING_DISTILLERY" = "true" || "$RELEASE_CMD" = "mix" ]]; then
     local _rpc_open_brackets="["
     local _rpc_close_brackets="]"
   else


### PR DESCRIPTION
Fixes some following error(s), while runnig migration commands:

```
** (TokenMissingError) nofile:1:39: missing terminator: ] (for "[" starting at line 1)
    |
  1 | Elixir.Edeliver.run_command([:migrate,
    |                                       ^
    (elixir 1.13.4) lib/code.ex:403: Code.validated_eval_string/3
```