### PR TITLE
Fix typos and markdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,71 +3,71 @@ eDeliver Versions
 
 __1.9.3__
 
-  - Enhancements
-    - handle `DOCKER_RELEASE_BASE_IMAGE` with `WORKDIR` set or set it automatically
+- Enhancements
+  - handle `DOCKER_RELEASE_BASE_IMAGE` with `WORKDIR` set or set it automatically
 
 __1.9.2__
 
-  - Fixes 
-    - include missing default file to start release containers into hex package
-    - list available releases on google container registry correctly
+- Fixes
+  - include missing default file to start release containers into hex package
+  - list available releases on google container registry correctly
 
 __1.9.1__
 
-  - Enhancements
-    - add `DOCKER_HUB_ACCESS_TOKEN` to list releases on Docker Hub
-    - improve listing of releases from Docker registry
+- Enhancements
+  - add `DOCKER_HUB_ACCESS_TOKEN` to list releases on Docker Hub
+  - improve listing of releases from Docker registry
 
-  - Fixes 
-    - creating release TAR when building in docker and with mix directly
-    - listing releases on Docker Hub 
+- Fixes
+  - creating release TAR when building in docker and with mix directly
+  - listing releases on Docker Hub
 
 __1.9.0__
 
-  - Enhancements
-    - support building in docker instead on a build host
-    - support building deployable docker containers containing the built release
-    - support `mix release` task
-    - run epmd-less in docker
-    - rebar3 support
+- Enhancements
+  - support building in docker instead on a build host
+  - support building deployable docker containers containing the built release
+  - support `mix release` task
+  - run epmd-less in docker
+  - rebar3 support
 
-  - Fixes 
-    - consider env when fetching deps
-    - consider DEPLOY_ENVIRONMENT when globally set
+- Fixes
+  - consider env when fetching deps
+  - consider DEPLOY_ENVIRONMENT when globally set
 
 __1.8.0__
 
-  - Backwards incompatible changes
-    - Elixir 1.10 compatibility by @progsmile. This is minimum required version now.
-    
+- Backwards incompatible changes
+  - Elixir 1.10 compatibility by @progsmile. This is minimum required version now.
+
 __1.7.0__
 
-  - Backwards incompatible changes
-    - Elixir 1.9 compatibility by @pablo-meier. This is minimum required version now.
-    - Distillery 2.1.0 compatibility by @nifoc. This is minimum required version now.
+- Backwards incompatible changes
+  - Elixir 1.9 compatibility by @pablo-meier. This is minimum required version now.
+  - Distillery 2.1.0 compatibility by @nifoc. This is minimum required version now.
 
 __1.6.0__
 
-  - Enhancements
-    - Support Distillery 2.x
-  - Backwards incompatible changes
-    - Distillery 1.x is not supported anymore
+- Enhancements
+  - Support Distillery 2.x
+- Backwards incompatible changes
+  - Distillery 1.x is not supported anymore
 
 __1.5.3__
 
-  - Fixes
-    - Truly fixes broken distillery compatibility by @TokiTori
+- Fixes
+  - Truly fixes broken distillery compatibility by @TokiTori
 
 __1.5.2__
 
-  - Fixes
-    - Fix broken distillery compatibility by @TokiTori
+- Fixes
+  - Fix broken distillery compatibility by @TokiTori
 
 __1.5.1__
 
-  - Enhancements
-    - Warnings cleanup by @kanmo
-    - New autoversion option "-time" by @tejanium
+- Enhancements
+  - Warnings cleanup by @kanmo
+  - New autoversion option "-time" by @tejanium
 
 __1.4.6__
 
@@ -82,7 +82,7 @@ _Good news everyone! Distillery compatibility is restored!_
   - Fix profile output dir (#254)
   - Fix posix compatibility (#147)
 - Backwards incompatible changes
-  - Exrm support removed . As discussed here: https://elixirforum.com/t/edeliver-plans-to-remove-exrm-support-any-objections/12416
+  - Exrm support removed . As discussed here: <https://elixirforum.com/t/edeliver-plans-to-remove-exrm-support-any-objections/12416>
 
 __1.4.5__
 
@@ -240,7 +240,6 @@ __1.1.0__
 - deploy release non-interactively if also upgrade exists
 - install hex non-interactive
 
-
 __1.0.0__
 
- - initial version with elixir support
+- initial version with elixir support

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
-### Precheck
+# Precheck
 
 * Please do not use the issues tracker for help or support (try [the wiki](https://github.com/boldpoker/edeliver/wiki), [elixir forum](https://elixirforum.com/c/elixir-questions/deployment), [#deployment on slack](https://elixir-lang.slack.com/), Stack Overflow, IRC, mailing list, etc.)
 * For proposing a new feature, please start a discussion at the [deployment category on the elixir forum](https://elixirforum.com/c/elixir-questions/deployment)
 * For bugs, do a quick search and make sure the bug has not yet been reported
 * Finally, be nice and have fun!
 
-### Environment
+## Environment
 
 * Edeliver version (`mix edeliver --version`):
 * Elixir version (`elixir -v`):
@@ -13,14 +13,14 @@
 * Operating system (on build / deploy hosts):
 * Are you using an umbrella project (yes|no):
 
-### Verbose output
+## Verbose output
 
 * Are there more information when running with `--verbose`?
 * Can you narrow down the code line causing the issue when running with `--debug`?
 * Please remove any private data from the output before pasting it here (login credentials, ip addresses user names etc.)
 
-### Current behavior
+## Current behavior
 
 Include executed edeliver command, error output etc.
 
-### Expected behavior
+## Expected behavior

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ _Deployment for Elixir and Erlang_
 [![License](https://img.shields.io/hexpm/l/edeliver.svg)](https://mit-license.org/)
 [![Last Updated](https://img.shields.io/github/last-commit/edeliver/edeliver.svg)](https://github.com/edeliver/edeliver/commits/master)
 
-
 **edeliver** is based on [deliver](https://github.com/gerhard/deliver) and enables you to build and deploy Elixir and Erlang applications and perform hot-code upgrades.
 
-The [erlang releases](http://www.erlang.org/doc/design_principles/release_handling.html) are built on a *remote* host that is similar to the production machines - or in a [*docker*](https://www.docker.com/) container. After being built, the release can then be deployed to one or more production machines.
+The [erlang releases](http://www.erlang.org/doc/design_principles/release_handling.html) are built on a _remote_ host that is similar to the production machines - or in a [_docker_](https://www.docker.com/) container. After being built, the release can then be deployed to one or more production machines.
 
 Once built, the [release](http://www.erlang.org/doc/design_principles/release_handling.html) contains the full [erts (erlang runtime system)](http://erlang.org/doc/apps/erts/users_guide.html), all [dependencies (erlang or elixir applications)](http://www.erlang.org/doc/design_principles/applications.html), the Elixir runtime, native port drivers, and your erlang/elixir application(s) in a standalone embedded node.
 
@@ -33,7 +32,6 @@ Once built, the [release](http://www.erlang.org/doc/design_principles/release_ha
 - [#deployment on Slack](https://elixir-lang.slack.com/)
 - [Community Wiki](https://github.com/boldpoker/edeliver/wiki) — _feel free to contribute!_
 
-
 ## Contents
 
 - [Quick Start](#quick-start)
@@ -46,7 +44,6 @@ Once built, the [release](http://www.erlang.org/doc/design_principles/release_ha
 - [Examples](#examples)
 - [License](#license)
 
-
 ## Quick Start
 
 Assuming an Elixir project, you already have a build server and a staging server, and you've created a database on your staging server already (there is no ecto.create, we skip straight to migrations).
@@ -56,7 +53,7 @@ Add edeliver and your build tool ([distillery](https://github.com/bitwalker/dist
 ```exs
 def application, do: [
   applications: [
-  	 ...
+    ...
     # Add edeliver to the END of the list
     :edeliver
   ]
@@ -120,24 +117,23 @@ mix edeliver start
 mix edeliver migrate
 ```
 
-
 ## Installation
 
 Because it is based on [deliver](https://github.com/gerhard/deliver), it uses only shell scripts and has no further dependencies except the Erlang/Elixir build system.
 
 It can be used with any one of these build systems:
 
-  * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [distillery](https://github.com/bitwalker/distillery) for elixir/erlang releases (recommended)
-  * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [relx](https://github.com/erlware/relx) for elixir/erlang releases
-  * [rebar3](https://github.com/erlang/rebar3) for pure erlang releases or in conjunction with [rebar_mix plugin](https://github.com/Supersonido/rebar_mix) to build also Elixir sources and dependencies
-  * [rebar](https://github.com/basho/rebar) for legacy pure erlang releases
+- [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [distillery](https://github.com/bitwalker/distillery) for elixir/erlang releases (recommended)
+- [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [relx](https://github.com/erlware/relx) for elixir/erlang releases
+- [rebar3](https://github.com/erlang/rebar3) for pure erlang releases or in conjunction with [rebar_mix plugin](https://github.com/Supersonido/rebar_mix) to build also Elixir sources and dependencies
+- [rebar](https://github.com/basho/rebar) for legacy pure erlang releases
 
 Edeliver tries to autodetect which system to use:
 
-  * If a `./mix.exs` and a `rel/config.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [distillery](https://github.com/bitwalker/distillery) is used to generate the releases / upgrades.
-  * If a `./relx.config` file exists in addition to a `./mix.exs` file, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [relx](https://github.com/erlware/relx) is used to generate the releases / upgrades.
-  * If a `./rebar.config` file exists but no `./relx.config`, [rebar3](https://github.com/erlang/rebar3) is used to fetch the dependencies, compile the sources and to build the release
-  * Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades. It is recommended to [migrate to rebar3](https://rebar3.readme.io/docs/from-rebar-2x-to-rebar3) in that case.
+- If a `./mix.exs` and a `rel/config.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [distillery](https://github.com/bitwalker/distillery) is used to generate the releases / upgrades.
+- If a `./relx.config` file exists in addition to a `./mix.exs` file, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [relx](https://github.com/erlware/relx) is used to generate the releases / upgrades.
+- If a `./rebar.config` file exists but no `./relx.config`, [rebar3](https://github.com/erlang/rebar3) is used to fetch the dependencies, compile the sources and to build the release
+- Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades. It is recommended to [migrate to rebar3](https://rebar3.readme.io/docs/from-rebar-2x-to-rebar3) in that case.
 
 This can be overridden by the config variables `BUILD_CMD=rebar3|rebar|mix`, `RELEASE_CMD=rebar3|rebar|mix|relx` and `USING_DISTILLERY=true|false` in `.deliver/config`.
 
@@ -148,7 +144,6 @@ It may be required to install and configure git on your build host. You may also
 The build host must be similar to the production/staging hosts.  For example, if you want to deploy to a production system based on Linux, the release must also be built on a Linux system.
 
 The Erlang runtime (OTP) and the Elixir runtime are packaged with the release—you do not have to install Erlang or Elixir separately on your production/staging servers.
-
 
 ### Mix considerations
 
@@ -180,38 +175,43 @@ def application, do: [
 
 When using [rebar3](https://github.com/erlang/rebar3), edeliver can be added as [rebar3 dependency](https://rebar3.readme.io/docs/dependencies). Just add it to your `rebar.config` (and ensure that a `./rebar3` binary/link is in your project directory):
 
-    {deps, [
-      % ...
-      {edeliver, {git, "git://github.com/edeliver/edeliver.git", {tag, "1.9.2"}}}
-    ]}.
+```erlang
+{deps, [
+  % ...
+  {edeliver, {git, "git://github.com/edeliver/edeliver.git", {tag, "1.9.2"}}}
+]}.
+```
 
 And link the `edeliver` binary to the root of your project directory:
 
-    wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
-    ./rebar3 get-deps
-    ln -s ./_build/default/lib/edeliver/bin/edeliver ./edeliver 
-
+```sh
+wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+./rebar3 get-deps
+ln -s ./_build/default/lib/edeliver/bin/edeliver ./edeliver
+```
 
 Then use the linked binary `./edeliver` to build and deploy releases. The `default` [rebar3 profile](https://rebar3.readme.io/docs/profiles) can be overridden by setting the `REBAR_PROFILE` environment variable in the edeliver config e.g. to `prod`.
-
 
 ### Rebar considerations
 
 When using rebar, edeliver can be added as [rebar](https://github.com/basho/rebar) dependency. Just add it to your `rebar.config` (and ensure that a `./rebar` binary/link is in your project directory):
 
-    {deps, [
-      % ...
-      {edeliver, "1.9.2",
-        {git, "git://github.com/boldpoker/edeliver.git", {branch, master}}}
-    ]}.
+```erlang
+{deps, [
+  % ...
+  {edeliver, "1.9.2",
+    {git, "git://github.com/boldpoker/edeliver.git", {branch, master}}}
+]}.
+```
 
 And link the `edeliver` binary to the root of your project directory:
 
-    ./rebar get-deps # when using rebar, or ...
-    ln -s ./deps/edeliver/bin/edeliver .
+```sh
+./rebar get-deps # when using rebar, or ...
+ln -s ./deps/edeliver/bin/edeliver .
+```
 
 Then use the linked binary `./edeliver` instead of the `mix edeliver` tasks from the examples.
-
 
 ## Configuration
 
@@ -262,14 +262,15 @@ For build commands the following **configuration** variables must be set:
 
 The built release is then **copied to your local directory** `.deliver/releases` and can then be **delivered to your production servers** by using one of the **deploy commands**.
 
-If compiling and generating the release build was successful, the release is **copied from the remote build host** to the **release store**. The default release store is the __local__ `.deliver` __directory__ but you can configure any destination with the `RELEASE_STORE=` environment variables, also __remote ssh destinations__ (in your server network) like `RELEASE_STORE=user@releases.acme.org:/releases/`, **amazon s3** locations like `s3://AWS_ACCESS_KEY_ID@AWS_SECRET_ACCESS_KEY:bucket` or as a __docker image__ like `docker://edeliver/echo-server`. The release is copied from the remote build host using the `RELEASE_DIR=` environment variable. If this is not set, the default directory is found by finding the subdirectory that contains the generated `RELEASES` file and has the `$APP` name in the path. e.g. if `$APP=myApp` and the `RELEASES` file is found at `rel/myApp/myApp/releases/RELEASE` the `rel/myApp/myApp` is copied to the release store.
+If compiling and generating the release build was successful, the release is **copied from the remote build host** to the **release store**. The default release store is the **local** `.deliver` **directory** but you can configure any destination with the `RELEASE_STORE=` environment variables, also **remote ssh destinations** (in your server network) like `RELEASE_STORE=user@releases.acme.org:/releases/`, **amazon s3** locations like `s3://AWS_ACCESS_KEY_ID@AWS_SECRET_ACCESS_KEY:bucket` or as a **docker image** like `docker://edeliver/echo-server`. The release is copied from the remote build host using the `RELEASE_DIR=` environment variable. If this is not set, the default directory is found by finding the subdirectory that contains the generated `RELEASES` file and has the `$APP` name in the path. e.g. if `$APP=myApp` and the `RELEASES` file is found at `rel/myApp/myApp/releases/RELEASE` the `rel/myApp/myApp` is copied to the release store.
 
-To __build releases__ and upgrades __faster__, you might adjust the `GIT_CLEAN_PATHS` variable in your config file e.g. to something like `="_build rel priv/generated"` which defaults to `.`. That value means, that everything from the last build is reset (beam files, release files, deps, generated assets etc.) before the next build is started to ensure that no conflicts with old (e.g. removed or renamed) files might arise. You can also use the command line option `--skip-git-clean` to skip this step completely and in addition with the `--skip-mix-clean` option for full __incremental builds__.
-
+To **build releases** and upgrades **faster**, you might adjust the `GIT_CLEAN_PATHS` variable in your config file e.g. to something like `="_build rel priv/generated"` which defaults to `.`. That value means, that everything from the last build is reset (beam files, release files, deps, generated assets etc.) before the next build is started to ensure that no conflicts with old (e.g. removed or renamed) files might arise. You can also use the command line option `--skip-git-clean` to skip this step completely and in addition with the `--skip-mix-clean` option for full **incremental builds**.
 
 ### Build Initial Release
 
-    mix edeliver build release [--revision=<git-revision>|--tag=<git-tag>] [--branch=<git-branch>]
+```sh
+mix edeliver build release [--revision=<git-revision>|--tag=<git-tag>] [--branch=<git-branch>]
+```
 
 Builds an initial release that can be deployed to the production hosts. If you want to build a different tag or revision, use the `--revision=` or the `--tag` argument. If you want to build a different branch or the tag / revision is in a different branch, use the `--branch=` argument.
 
@@ -279,7 +280,7 @@ If `BUILD_HOST` is set to `"docker"`, edeliver builds the release in a docker co
 
 ### Build as a docker container
 
-If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to [`edeliver/release-base:1.0`](https://hub.docker.com/r/edeliver/release-base)) and pushed with that image name from the `RELEASE_STORE` to your registry (if `--push` is used). It creates (and optionally pushes) three image tags: *release version* + `latest`, *release version* + *git sha* and *release version* + *branch*. The release can then be started on a host authenticated at the same docker registry like this:
+If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to [`edeliver/release-base:1.0`](https://hub.docker.com/r/edeliver/release-base)) and pushed with that image name from the `RELEASE_STORE` to your registry (if `--push` is used). It creates (and optionally pushes) three image tags: _release version_ + `latest`, _release version_ + _git sha_ and _release version_ + _branch_. The release can then be started on a host authenticated at the same docker registry like this:
 
 ```sh
 docker start -ti edeliver/echo-server:1.0-latest -p 8080:8080 echo-server/bin/echo-server console
@@ -287,23 +288,24 @@ docker start -ti edeliver/echo-server:1.0-latest -p 8080:8080 echo-server/bin/ec
 
 ### Build an upgrade package
 
-    mix edeliver build upgrade --from=<git-tag-or-revision>|--with=<release-version-from-store>
-                              [--to=<git-tag-or-revision>] [--branch=<git-branch>]
+```sh
+mix edeliver build upgrade --from=<git-tag-or-revision>|--with=<release-version-from-store>
+  [--to=<git-tag-or-revision>] [--branch=<git-branch>]
+```
 
 Builds an _upgrade_ package that can be deployed to production hosts with running nodes _without restarting_ them. To build an upgrade package you need the release or upgrade package (when using [distillery](https://github.com/bitwalker/distillery)) of the running release. If it is available (in the release store), you can build the upgrade to the new version by passing the old  version to the `--with=<old-version>` option. If not, you can build the old release and the live upgrade from it in a single step by using the `--from=<git-tag-or-revision>` option. If you don't want to build an upgrade to the current head of the given branch (`master` is the default), you can use the `--to=<git-tag-or-revision>` option. If the upgrade package is built, you might want to _modify_ the generated upgrade instructions ([relup](http://www.erlang.org/doc/man/relup.html)) as described in the next section or (more advanced) automatically patch the relup file by implementing your own [`Edeliver.Relup.Modification`](https://github.com/boldpoker/edeliver/blob/master/lib/edeliver/relup/modification.ex)behaviour to automate this step.
 
-
 ### Edit upgrade instructions (relup)
 
-    mix edeliver edit relup [--version=<upgrade-version>]
+```sh
+mix edeliver edit relup [--version=<upgrade-version>]
+```
 
 From the auto-generated appup instructions of all included and updated applications, a [relup](http://www.erlang.org/doc/man/relup.html) file is generated during the `build upgrade` command and included in the upgrade package.  It contains the upgrade instructions for the new release version.  If there are dependencies between modules or applications, it might be necessary to modify this file, e.g. changing the order of the applications or modules that are reloaded.  If there are repeating steps to adjust the relup for your application, you can automate this step by implementing your own [`Edeliver.Relup.Modification`](https://github.com/boldpoker/edeliver/blob/master/lib/edeliver/relup/modification.ex) behavior.
-
 
 ### Auto-Versioning
 
 edeliver provides a way to automatically increment the current version for the current build and/or to append [metadata](http://semver.org/#spec-item-10) to the version (such as the current git sha).  Having unique versions for each release is important especially if you build hot code upgrades.  It also helps to determine exactly which version is running when using `mix edeliver version`.  For more information check the `--auto-version=` option described e.g in `mix edeliver help upgrade` or in the [wiki](https://github.com/boldpoker/edeliver/wiki/Auto-Versioning).
-
 
 ### Build Restrictions (rebar)
 
@@ -311,10 +313,11 @@ To build upgrades, there must be only one release in the release directory (`rel
 You can then pass the config file to use by setting the environment `REBAR_CONFIG=` at the command line.
 The reason for that is, that when the upgrade is build with rebar, rebar tries to find the old version in both release directories.
 
-
 ## Deploy Commands
 
-    mix edeliver deploy release|upgrade [[to] staging|production] [--version=<release-version>] [Options]
+```sh
+mix edeliver deploy release|upgrade [[to] staging|production] [--version=<release-version>] [Options]
+```
 
 Deploy commands deliver the builds that were created with a build command to your staging or production hosts.  They can also perform a live code upgrade.  Built releases or upgrades are available in your local directory `.deliver/releases`.  To deploy releases the following configuration variables must be set:
 
@@ -329,7 +332,7 @@ Deploy commands deliver the builds that were created with a build command to you
 
 Deploying to staging can be used to test your releases and upgrades before deploying them to the production hosts.  Staging is the default target if you don't pass the `[to] production` argument.
 
-If the `RELEASE_STORE` is a docker image, the deploy command pulls and starts the image with the given tag as version. See section __Deploy Docker Releases__ below for details.
+If the `RELEASE_STORE` is a docker image, the deploy command pulls and starts the image with the given tag as version. See section **Deploy Docker Releases** below for details.
 
 ### Deploy an initial/clean release
 
@@ -340,7 +343,6 @@ mix edeliver deploy
 Deploys an initial release at the production hosts.  This requires that the `build release` command was executed before.
 
 If there are several releases in the release store, you will be asked which release to deploy or you can pass the version by the `--version=` argument variable.  If the nodes on the remote deploy hosts are up, the running old release is not affected—the new release will be available only after starting or restarting the nodes on the deploy hosts.
-
 
 ### Deploy an upgrade
 
@@ -356,17 +358,19 @@ This command requires that your release start script was **generate** by a **rec
 
 If using rebar, make sure that the [install_upgrade.escript](https://github.com/basho/rebar/blob/master/priv/templates/simplenode.install_upgrade.escript) file which was generated by rebar is included in your release. So ensure, that the following line is in your `reltool.config`:
 
-    {overlay, [ ...
-           {copy, "files/install_upgrade.escript", "bin/install_upgrade.escript"}
-    ]}.
+```erlang
+{overlay, [ ...
+       {copy, "files/install_upgrade.escript", "bin/install_upgrade.escript"}
+]}.
+```
 
 ### Deploy Docker Releases
 
-When embedding releases into docker containers, the deploy command pulls the docker image from the registry defined as `RELEASE_STORE` and __extracts the boot script__ from `/$APP/bin/start_container` (can be configured in `CONTAINER_START_SCRIPT`) to `$DELIVER_TO/bin` while replacing the string `{{edeliver-version}}` with the version which is deployed. The script should use that value to always start that tag of the image.
+When embedding releases into docker containers, the deploy command pulls the docker image from the registry defined as `RELEASE_STORE` and **extracts the boot script** from `/$APP/bin/start_container` (can be configured in `CONTAINER_START_SCRIPT`) to `$DELIVER_TO/bin` while replacing the string `{{edeliver-version}}` with the version which is deployed. The script should use that value to always start that tag of the image.
 
 The start script should handle the same commands as the [extended start script from relx/rebar](https://rebar3.readme.io/docs/releases#extensions), at least the `start`, `stop` and `version` commands.
 
-It could start the container with e.g. like this 
+It could start the container with e.g. like this
 
 ```sh
 VERSION="{{edeliver-version}}"
@@ -391,7 +395,6 @@ mix edeliver migrate production # run database migrations
 mix edeliver restart production # or start or stop
 ```
 
-
 ## Help
 
 If something goes wrong, retry with the `--verbose` option.  If you want to see everything, try the `--debug` option.
@@ -402,40 +405,39 @@ For advanced usage have a look also at the [wiki](https://github.com/boldpoker/e
 
 Definitely join the #deployment channel in the [Elixir Slack community](https://elixir-lang.slack.com/) as well.
 
-
 ### Recommended Project Structure
 
-
-    your-app/                              <- project root dir
-      + rebar                              <- rebar binary
-      + mix                                <- optional mix binary when compiling with mix
-      + relx                               <- optional relx binary if rebar is not used
-      + edeliver                           <- edeliver binary linking to deps/deliver/bin/deliver
-      + rebar.config                       <- should have "rel/your-app" in the sub_dirs section
-      + mix.exs                            <- if present, mix is used for dependencies and compile
-      + relx.config                        <- if present, relx is used for releases
-      + .deliver                           <- default release store
-      |  + releases/*.tar.gz               <- the built releases / upgrade packages
-      |  + appup/OldVsn-NewVsn/*.apppup    <- generated appup files
-      |  + config                          <- deliver configuration
-      + src/                               <- erlang source files
-      |  + *.erl
-      |  + your-app.app.src
-      + lib/                               <- elixir source files
-      |  + *.ex
-      + priv/
-      + deps/
-      |  + edeliver/
-      + rel/
-         + your-app/
-             + files/
-             |   + your-app                <- binary to start|stop|upgrade your app
-             |   + nodetool                <- helper for your-app binary
-             |   + install-upgrade.escript <- helper for the upgrade task of your-app binary
-             |   + sys.config              <- app configuration for the release build
-             |   + vm.args                 <- erlang vm args for the node
-             + reltool.config              <- should have the install_upgrade.escript in overlay section
-
+```sh
+your-app/                              <- project root dir
+  + rebar                              <- rebar binary
+  + mix                                <- optional mix binary when compiling with mix
+  + relx                               <- optional relx binary if rebar is not used
+  + edeliver                           <- edeliver binary linking to deps/deliver/bin/deliver
+  + rebar.config                       <- should have "rel/your-app" in the sub_dirs section
+  + mix.exs                            <- if present, mix is used for dependencies and compile
+  + relx.config                        <- if present, relx is used for releases
+  + .deliver                           <- default release store
+  |  + releases/*.tar.gz               <- the built releases / upgrade packages
+  |  + appup/OldVsn-NewVsn/*.apppup    <- generated appup files
+  |  + config                          <- deliver configuration
+  + src/                               <- erlang source files
+  |  + *.erl
+  |  + your-app.app.src
+  + lib/                               <- elixir source files
+  |  + *.ex
+  + priv/
+  + deps/
+  |  + edeliver/
+  + rel/
+     + your-app/
+         + files/
+         |   + your-app                <- binary to start|stop|upgrade your app
+         |   + nodetool                <- helper for your-app binary
+         |   + install-upgrade.escript <- helper for the upgrade task of your-app binary
+         |   + sys.config              <- app configuration for the release build
+         |   + vm.args                 <- erlang vm args for the node
+         + reltool.config              <- should have the install_upgrade.escript in overlay section
+```
 
 ## Examples
 
@@ -453,7 +455,7 @@ Or execute the above steps with a single command:
 mix edeliver update production --branch=feature --start-deploy
 ```
 
-Build a *live* upgrade from v1.0 to v2.0 for a release and deploy it to production:
+Build a _live_ upgrade from v1.0 to v2.0 for a release and deploy it to production:
 
 ```sh
 # build upgrade from tag v1.0 to v2.0
@@ -476,23 +478,21 @@ The deployed upgrade will be **available immediately, without restarting** your 
 
 To execute that steps by a single command and upgrade e.g. all production nodes **automatically**  from their running version to the current version using **hot code upgrade** without restarting, you can use the `upgrade` command:
 
-```
+```sh
 mix edeliver upgrade production
 ```
 
 This performs the following steps automatically:
 
-* Detect current version on all running nodes
-* Validate that all nodes run the same version
-* Build new upgrade from that version to the current version
-* Auto-patch the relup file
-* Deploy (hot code) upgrade while nodes are running
-* Validate that all nodes run the upgraded version
-* Deploy the release to not running nodes
-
+- Detect current version on all running nodes
+- Validate that all nodes run the same version
+- Build new upgrade from that version to the current version
+- Auto-patch the relup file
+- Deploy (hot code) upgrade while nodes are running
+- Validate that all nodes run the upgraded version
+- Deploy the release to not running nodes
 
 ---
-
 
 ## LICENSE
 

--- a/docker/start_container
+++ b/docker/start_container
@@ -142,7 +142,7 @@ case "$COMMAND" in
   *) # e.g. remote | remote_console | ping
     DOCKER_OPTS=" --network host"
     if [ "$RELEASE_CMD" = "rebar3" ]; then
-      # extended start script from rebar uses this to connecto to the
+      # extended start script from rebar uses this to connect to the
       # remote node for ping or remote_console command
       DOCKER_OPTS+=" --env ERL_DIST_PORT=${ERL_DIST_PORT}" 
     else
@@ -172,7 +172,7 @@ DOCKER_OPTS+=" --env RELEASE_NODE=${RELEASE_NODE}"
 
 if [ "$COMMAND" = "start" ] || [ "$COMMAND" = "daemon" ]; then
   DOCKER_OPTS+=" --detach --tty"
-elif [ -t 0 ]; then # terminal attatched
+elif [ -t 0 ]; then # terminal attached
   DOCKER_OPTS+=" --tty --interactive" 
 fi
 

--- a/guides/auto-versioning.md
+++ b/guides/auto-versioning.md
@@ -1,12 +1,11 @@
-### Using Auto-Versioning
+# Using Auto-Versioning
 
 edeliver provides a way to automatically __increment__ the current __version__ for the __current build__ and/or to __append__ the __git commit count__ and/or __revision__ as [version metadata](http://semver.org/#spec-item-10).
 __Using a different versions for each release is essential__ especially if you build hot code __upgrades__, but also makes sense to see which version is running, e.g. when using `mix edeliver version [staging|production]`.
 
 Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` command line option or the `SKIP_MIX_CLEAN=true` config respectively*.
 
-
-##### Append git commit count and/or revision to the release version
+## Append git commit count and/or revision to the release version
 
 ```sh
   mix release.version show
@@ -21,7 +20,7 @@ Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` c
   # creates version 1.0.0+82a5834-3027
 ```
 
-##### Append other metadata: git branch or build date
+## Append other metadata: git branch or build date
 
 ```sh
   mix release.version show
@@ -36,7 +35,7 @@ Notice: This feature cannot be used in conjunction with the `--skip-mix-clean` c
   # creates version 1.0.0+82a5834-20160414
 ```
 
-##### Append metadata to version permanently
+## Append metadata to version permanently
 
 To append metadata permanently you can set the `AUTO_VERSION` configuration variable in your `.deliver/config` file. This can be overridden by the `--auto-version=` command line argument.
 
@@ -45,24 +44,21 @@ To append metadata permanently you can set the `AUTO_VERSION` configuration vari
  AUTO_VERSION=commit-count+git-revision+branch-unless-master
 ```
 
-##### Available metadata which can be appended to the release version
+## Available metadata which can be appended to the release version
 
-
-  * `[git-]revision` Appends sha1 git revision of current HEAD.
-  * `[git-]branch` Appends the current branch that is built.
-  * `[git-]branch-unless-master` Appends the current branch that is built but only unless it is the master branch.
-  * `[build-]date` Appends the build date as YYYYMMDD.
-  * `[build-]time` Appends the build time as HHMMSS.
-  * `[git-]commit-count[-all[-branches]` Appends the number of commits across all branches.
+* `[git-]revision` Appends sha1 git revision of current HEAD.
+* `[git-]branch` Appends the current branch that is built.
+* `[git-]branch-unless-master` Appends the current branch that is built but only unless it is the master branch.
+* `[build-]date` Appends the build date as YYYYMMDD.
+* `[build-]time` Appends the build time as HHMMSS.
+* `[git-]commit-count[-all[-branches]` Appends the number of commits across all branches.
     Allows edeliver to detect which version is newer if it is appended as first metadata to
     the release version.
-  * `[git-]commit-count-branch` Appends the number of commits from the current branch.
+* `[git-]commit-count-branch` Appends the number of commits from the current branch.
     This makes more sense, if the branch name is also appended as metadata to avoid
     conflicts from different branches.
 
-
 Using __commit count across all branches__ (`commit-count[-all[-branches]`) __or__ using the __build date__ (`[build-]date`) __as first metadata__ to append, enables edeliver to __consider__ that values __when sorting__ versions. Using `[git-]revision` or commit count for the current branch in conjunction with the branch name (`commit-count-branch+branch`) enables you to __uniquely identify__ the built/deployed __version__. If the revision is used, __edeliver can display the commit message for that version__ (and the 5 previous commit messages) if `edeliver version [staging|production]` is used. To achieve both (sorting and identifying versions) and to see whether a feature branch is built/deployed, the following permanent auto-versioning option is recommended: `AUTO_VERSION=commit-count+git-revision+branch-unless-master`.
-
 
 For more information also try `mix edeliver help upgrade`, `mix edeliver help release` or `mix help release.version`.
 
@@ -114,7 +110,7 @@ VERSION DONE!
 
 Then number of commits can be adjusted by the `VERSION_INFO_LAST_COMMITS` env / config.
 
-##### Increment / Set Version for the current release / upgrade
+## Increment / Set Version for the current release / upgrade
 
 ```sh
   mix release.version show
@@ -132,7 +128,7 @@ Then number of commits can be adjusted by the `VERSION_INFO_LAST_COMMITS` env / 
 
 `--increment-version=` and `--set-version=` can be used in conjunction with the `--auto-version=` option. The `AUTO_VERSION` default is also used unless the `--auto-version=` overrides it.
 
-##### Use the Auto-Versioning / Increment-Version mix task locally
+## Use the Auto-Versioning / Increment-Version mix task locally
 
 You can also use the auto versioning mix task provided by edeliver locally on your development machine, e.g. when testing your release / upgrade. The argument names to append metadata differ slightly and contain an (optional) `append-` prefix. If version modifiers are combined, they can be separated by a space (or by the `+` character as for the edeliver option).
 It is required to clean the build output before* and to run the `release.version` and `release` mix tasks together using the `mix do` task while running the `release.version` task before the `release` task.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,7 +1,6 @@
 # Configuration (.deliver/config)
 
-
-### Required Configuration
+## Required Configuration
 
 This options can or must be set in the `.deliver/config` file to configure edeliver:
 
@@ -23,10 +22,9 @@ This options can or must be set in the `.deliver/config` file to configure edeli
 
 See also [Configuration Section](https://github.com/boldpoker/edeliver#user-content-configuration) in the [README](https://github.com/boldpoker/edeliver/blob/master/README.md).
 
-### Use edeliver Options Permanently
+## Use edeliver Options Permanently
 
 This options can be set in the `.deliver/config` file to use the command line option permanently without passing them every time:
-
 
 | environment variable in config file   | edeliver argument    | info                                          |
 |---------------------------------------|----------------------|-----------------------------------------------|
@@ -43,11 +41,9 @@ This options can be set in the `.deliver/config` file to use the command line op
 Passing any of that arguments to edeliver overrides the value set in the config file.
 Try also `edeliver help build release`, `edeliver help build upgrade` or `edeliver help deploy release` for more information.
 
-### Additional Environment Variables available in config file
-
+## Additional Environment Variables available in config file
 
 This environment variables are set by edeliver and can be used `.deliver/config` file to adjust something:
-
 
 | environment variable  | possible values         |
 |-----------------------|-------------------------|

--- a/guides/docker.md
+++ b/guides/docker.md
@@ -2,7 +2,6 @@
 
 edeliver also provides support for docker containers. It provides
 
-
   1. building in a docker container, which makes the need of a build host obsolete and …
   2. building a docker image which contains the release and can run the release as a docker container.
 
@@ -64,9 +63,11 @@ DOCKER_OPTS+=" --mount type=bind,source=/etc/echo-server,target=/etc/echo-server
 ```
 
 ## Building in a Docker Container
+
 To build the release in a docker container (1.), `BUILD_HOST="docker"` must be set and optionally the `DOCKER_BUILD_IMAGE` which will be pulled and used to build the release, similar to a build host and should contain all tools needed. [elixir:1.13.3](https://hub.docker.com/_/elixir) is the default `DOCKER_BUILD_IMAGE` but you could also use [existing extended images](https://hub.docker.com/r/enpedasi/nodejs-phoenix), e.g. to build a [phoenix](https://phoenixframework.org/) app or build an own docker image containing everything required by your app.
 
 ## Building a Docker Image
+
 To also embed the built release into a docker image (2.), edeliver needs to be configured to use a docker registry as release store by setting it e.g. like this in the `.deliver/config` file: `RELEASE_STORE="docker://<account-name>/<release-image-name>`, e.g. `docker://edeliver/echo-server` or `docker://eu.gcr.io/edeliver/echo-server`.
 
 Edeliver then pulls a (runtime) base image from `DOCKER_RELEASE_BASE_IMAGE` (which defaults to [edeliver/release-base:1.0](https://hub.docker.com/r/edeliver/release-base)), copies the release into it and commits a new docker image as `/<account-name>/<release-image-name>:<release-version>-<git-rev>`, e.g. `edeliver/echo-server:1.0-f5ddf03` which can be pushed manually to the registry or automatically with the `--push` flag. This is the image which can be deployed and started on the staging or production hosts. Ensure the **docker daemon is authenticated** at the (private) registry by running `docker login` before or `gcloud auth login` etc.
@@ -99,12 +100,15 @@ To achieve this, edeliver starts the release **epmd-les**s and with an own [epmd
 
 By default a node started by edeliver in a container **binds to a fixed distribution port** set as `ERL_DIST_PORT` env, by default `4321`. Known nodes which are configured to run on a different port (e.g. because they run on the same host) can be configured by the `nodes` `edeliver` application config e.g. in the `sys.config` file of the release or be passed space-separated in the `EDELIVER_NODES` environment variable. The port can be specified separated by a `:` if it does not listen on the default `ERL_DIST_PORT` or `DEFAULT_DIST_PORT` respectively which precedes the latter.
 e.g.
-```
+
+```sh
 EDELIVER_NODES="foo@bar.local baz@bar.local:4323` bin/my-app console
 ```
+
 Starts a my-app node which can connect to `foo@bar.local` at distribution port `4321` and to
 node `baz@bar.local` at port `4323`. Same can be achieved when setting it in the sys.config
-```
+
+```erlang
  [{kernel, [{net_ticktime. 20}, …]},
   {edeliver, [{nodes, ['foo@bar.local', 'baz@bar.local:4323']},
   …]}]
@@ -116,7 +120,7 @@ The docker container listens by default on `127.0.0.1` for connections from othe
 
 When using distillery to build a docker release with edeliver, you must use long node names while edeliver will configre distillery to replace the `$HOST` env in the `vm.args` file, which should look like this:
 
-```
+```erlang
 -name my_app@${HOST_NAME}
 
 +K true
@@ -147,7 +151,7 @@ Ensure edeliver is added as dependency and included into the release:
 
 When using rebar3 to build a docker release with edeliver, you can use short node names but need to configure the `inet_dist_use_interface` in your `vm.args.src` file, while edeliver will configre rebar3 to replace the `$INET_DIST_USE_INTERFACE` env in the `vm.args.src` file. It should look like this:
 
-```
+```erlang
 -sname eco
 
 -kernel inet_dist_use_interface ${INET_DIST_USE_INTERFACE}
@@ -158,7 +162,7 @@ When using rebar3 to build a docker release with edeliver, you can use short nod
 
 Using a `vm.args.src` file which replaces env vars is enabled in the `rebar3.config` like this:
 
-```
+```erlang
 {relx, [{release, { my_app, "0.1.0" }, [sasl, edeliver, …]},
 
         …
@@ -191,5 +195,3 @@ When using mix to build a docker release with edeliver, just ensure that edelive
      {:edeliver, "~> 1.9.2"}]
   end
 ```
-
-

--- a/guides/relup-patching.md
+++ b/guides/relup-patching.md
@@ -20,23 +20,23 @@ To disable the automatic relup modifications you can use the `--skip-relup-mod` 
 
 If you want or need to implement your own `Edeliver.Relup.Modification`, the following instructions provided by edeliver can be used:
 
- - `Edeliver.Relup.Instructions.CheckProcessesRunningOldCode`: aborts the upgrade if processes uses old code from previous upgrades
- - `Edeliver.Relup.Instructions.CheckRanchAcceptors`: checks whether ranch acceptors can be found or aborts the upgrade
- - `Edeliver.Relup.Instructions.CheckRanchConnections`: checks whether ranch connections can be found or aborts the upgrade
- - `Edeliver.Relup.Instructions.CodeChangeOnAppProcesses`: runs `code_change` on suspended processes
- - `Edeliver.Relup.Instructions.FinishRunningRequests`: notifies running phoenix requests that an upgrade starts
- - `Edeliver.Relup.Instructions.Info`: prints info to the log on the nodes and the edeliver upgrade output
- - `Edeliver.Relup.Instructions.ReloadModules`: reloads changed modules
- - `Edeliver.Relup.Instructions.RerunFailedRequests`: reruns phoenix requests that failed during the upgrade
- - `Edeliver.Relup.Instructions.ResumeAppProcesses`: resumes suspended processes
- - `Edeliver.Relup.Instructions.ResumeChannels`: resumes suspended phoenix channels
- - `Edeliver.Relup.Instructions.ResumeRanchAcceptors`: resumes suspended ranch acceptors
- - `Edeliver.Relup.Instructions.Sleep`: sleeps some time. useful for upgrade testing
- - `Edeliver.Relup.Instructions.SoftPurge`: replaces `:brutal_purge` with `:soft_purge` in code-loading instructions
- - `Edeliver.Relup.Instructions.StartSection`: prints info to the log on the nodes and the edeliver upgrade output that a new upgrade section starts
- - `Edeliver.Relup.Instructions.SuspendAppProcesses`: suspends processes using changed code
- - `Edeliver.Relup.Instructions.SuspendChannels`: suspends phoenix channels
- - `Edeliver.Relup.Instructions.SuspendRanchAcceptors`: suspends ranch acceptors
+- `Edeliver.Relup.Instructions.CheckProcessesRunningOldCode`: aborts the upgrade if processes uses old code from previous upgrades
+- `Edeliver.Relup.Instructions.CheckRanchAcceptors`: checks whether ranch acceptors can be found or aborts the upgrade
+- `Edeliver.Relup.Instructions.CheckRanchConnections`: checks whether ranch connections can be found or aborts the upgrade
+- `Edeliver.Relup.Instructions.CodeChangeOnAppProcesses`: runs `code_change` on suspended processes
+- `Edeliver.Relup.Instructions.FinishRunningRequests`: notifies running phoenix requests that an upgrade starts
+- `Edeliver.Relup.Instructions.Info`: prints info to the log on the nodes and the edeliver upgrade output
+- `Edeliver.Relup.Instructions.ReloadModules`: reloads changed modules
+- `Edeliver.Relup.Instructions.RerunFailedRequests`: reruns phoenix requests that failed during the upgrade
+- `Edeliver.Relup.Instructions.ResumeAppProcesses`: resumes suspended processes
+- `Edeliver.Relup.Instructions.ResumeChannels`: resumes suspended phoenix channels
+- `Edeliver.Relup.Instructions.ResumeRanchAcceptors`: resumes suspended ranch acceptors
+- `Edeliver.Relup.Instructions.Sleep`: sleeps some time. useful for upgrade testing
+- `Edeliver.Relup.Instructions.SoftPurge`: replaces `:brutal_purge` with `:soft_purge` in code-loading instructions
+- `Edeliver.Relup.Instructions.StartSection`: prints info to the log on the nodes and the edeliver upgrade output that a new upgrade section starts
+- `Edeliver.Relup.Instructions.SuspendAppProcesses`: suspends processes using changed code
+- `Edeliver.Relup.Instructions.SuspendChannels`: suspends phoenix channels
+- `Edeliver.Relup.Instructions.SuspendRanchAcceptors`: suspends ranch acceptors
 
 #### Custom Instructions
 

--- a/lib/edeliver/relup/instructions/finish_running_requests.ex
+++ b/lib/edeliver/relup/instructions/finish_running_requests.ex
@@ -13,7 +13,7 @@ defmodule Edeliver.Relup.Instructions.FinishRunningRequests do
 
     `Edeliver.Relup.Instructions.SuspendRanchAcceptors`
 
-    instruction which avoids that new requets are accepted
+    instruction which avoids that new requests are accepted
     during the upgrade.
 
     To make sure that the http request connections can
@@ -135,7 +135,7 @@ defmodule Edeliver.Relup.Instructions.FinishRunningRequests do
       info "Waiting for #{inspect requests_count} requests..."
       remaining_requests = bulk_wait_for_termination(request_connections, timeout)
       remaining_requests_count = Enum.count(remaining_requests)
-      info "#{inspect requests_count-remaining_requests_count} requets finished."
+      info "#{inspect requests_count-remaining_requests_count} requests finished."
       if remaining_requests_count > 0 do
         info "#{inspect remaining_requests_count} requests will be restarted after upgrade if they failed."
         notify_running_requests(remaining_requests, :upgrade_started)

--- a/libexec/core
+++ b/libexec/core
@@ -407,7 +407,7 @@ __sync_local() {
 
 # Executes a docker command and hides output unless --verbose flag is set.
 # The output is captured and displayed in case of a failure. If this
-# runs in a subshell e.g. to assign the output to a vaiable 
+# runs in a subshell e.g. to assign the output to a variable 
 # (a container id for instance), the output is printed.
 __docker() {
   if [ "$(exec sh -c 'echo "$PPID"')" != "$$" ]; then

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -137,7 +137,7 @@ stop_build_container() {
 # starts the build container with the DOCKER_BUILD_IMAGE image
 # and automatically pulls it if not available locally. Pull output
 # is hidden until executed with --verbose. The container is started
-# detatched and the container id is set to DOCKER_BUILD_CONTAINER
+# detached and the container id is set to DOCKER_BUILD_CONTAINER
 start_build_container() {
   status "Creating build container"
   info "Starting build container with image $DOCKER_BUILD_IMAGE"
@@ -474,7 +474,7 @@ EOF
 
     local _valid_docker_tag
     _valid_docker_tag="$(echo "$RELEASE_VERSION" | sed 's/[^0-9A-Za-z_.-]*//g')"
-    info "Commiting as ${_valid_docker_tag}-latest"
+    info "Committing as ${_valid_docker_tag}-latest"
     local _release_command="$RELEASE_CMD"
     if [ "$_release_command" = "mix" ]; then
       if ! [ "$USING_DISTILLERY" = "false" ]; then
@@ -923,7 +923,7 @@ __get_releases_in_store() {
       fi
     else
       local _image_info _tag _created_at
-      # e.g. for google container registry containing detaild information about tags and their timestamps:
+      # e.g. for google container registry containing detailed information about tags and their timestamps:
       # {"manifest": {"sha256:03302a…": {"timeCreatedMs":…, "tag":["tag1"], …}, "tags":["tag1","tag2"]}
       if echo "$_out" | grep -oe '{[^}]\+\"tag\"\s*:\s*\[[^}]\+' >/dev/null 2>&1; then
         for _image_info in $(echo "$_out" | grep -oe '{[^}]\+\"tag\"\s*:\s*\[[^}]\+'); do
@@ -934,7 +934,7 @@ __get_releases_in_store() {
           fi
         done | sort -n | cut -d' ' -f 2-
       else
-        # dockerhub does not have a list of single tags with timestamps, so access the tags direclty
+        # dockerhub does not have a list of single tags with timestamps, so access the tags directly
         # from a struct like: {"name":"user-name/image-name","tags":["tag1","tag2"]}
         echo "$_out" | grep -oe '\"tags\"\s*:\s*\[[^]]\+' | cut -f2 -d "[" | grep -oe '"[^"]\+"' | tr -d '"' | tr "\n" " "
       fi
@@ -1262,7 +1262,7 @@ remote_extract_release_archive() {
         cat >\"$APP\"
       }
       chmod 700 \"$APP\"
-      # read which release command was used from the docker image lables because
+      # read which release command was used from the docker image labels because
       # releases built with rebar3 needs a different ERL_DIST_PORT set when starting the remote console
       # as releases built with distillery. For distillery it needs to be a random port (0) while
       # for rebar3 it needs to be the port the actual server listens on.

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -1,15 +1,17 @@
+# Strategy
+
 Deliver will use the ruby strategy by default. If you want to use a different
 one, define it in your `.deliver/config` file. Alternatively, pass it as at runtime:
 
-    $ STRATEGY=nodejs deliver
+```sh
+STRATEGY=nodejs deliver
+```
 
 If you want to implement your own strategy, fork away. Currently,
 deliver only works with strategies defined in the local `strategies`
 directory, but with very little effort it can support any strategy
 specific to your setup.  All strategies in your local
 `.deliver/strategies` directory are automatically available.
-
-
 
 ## Conventions
 


### PR DESCRIPTION
Found via these commands:

    codespell -L daa,ques
    markdownlint -f *.md guides/*.md strategies/*.md --disable MD013 MD036 Md041