### PR TITLE
Add monorepo support via APP_SUBDIR configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ BUILD_HOST="build-system.acme.org" # host where to build the release, or "docker
 BUILD_USER="build" # local user at build host
 BUILD_AT="/tmp/erlang/my-app/builds" # build directory on build host
 
+# For monorepos: specify subdirectory where the app is located
+# APP_SUBDIR="apps/my-app" # optional: relative path from repo root
+
 STAGING_HOSTS="test1.acme.org test2.acme.org" # staging / test hosts separated by space
 STAGING_USER="test" # local user at staging hosts
 TEST_AT="/test/my-erlang-app" # deploy directory on staging hosts. default is DELIVER_TO
@@ -234,6 +237,17 @@ PRODUCTION_HOSTS="deploy1.acme.org deploy2.acme.org" # deploy / production hosts
 PRODUCTION_USER="production" # local user at deploy hosts
 DELIVER_TO="/opt/my-erlang-app" # deploy directory on production hosts
 ```
+
+### Monorepo Support
+
+If your application is part of a monorepo (i.e., not located in the root directory of your git repository), you can use the `APP_SUBDIR` configuration variable to specify where your application is located relative to the repository root:
+
+```sh
+# .deliver/config
+APP_SUBDIR="apps/my-app"  # Path to your app relative to repository root
+```
+
+This allows edeliver to properly navigate to your application directory during the build process on the remote build host.
 
 To use different configurations on different hosts, you can [configure edeliver to link](https://github.com/boldpoker/edeliver/wiki/Use-per-host-configuration) the `vm.args` and/or the `sys.config` files in the release package by setting the `LINK_VM_ARGS=/path/to/vm.args` and/or `LINK_SYS_CONFIG=/path/to/sys.config` variables in the edeliver config if you use [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) and [distillery](https://github.com/bitwalker/distillery) to build the releases.
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -8,6 +8,7 @@ This options can or must be set in the `.deliver/config` file to configure edeli
 | environment variable   | required | info                                           |
 |------------------------|----------|------------------------------------------------|
 | `APP`                  |      yes | the lower case name of your app                |
+| `APP_SUBDIR`           |       no | subdirectory in repo where app is located (for monorepos) |
 | `BUILD_AT`             |      yes | the directory on the build host to build at    |
 | `BUILD_CMD`            |       no | tool used to build sources. (mix\|rebar)        |
 | `BUILD_HOST`           |      yes | the host to build at                           |

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -14,7 +14,10 @@ defmodule Releases.Plugin.LinkConfig do
     end
     ```
   """
-  use Distillery.Releases.Plugin
+  
+  # Manual behavior implementation to avoid circular dependency during compilation
+  alias Distillery.Releases.Release
+  import Distillery.Releases.Shell, only: [debug: 1, info: 1]
 
 
   def before_assembly(_, _), do: nil

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -16,8 +16,10 @@ defmodule Releases.Plugin.LinkConfig do
   """
   
   # Manual behavior implementation to avoid circular dependency during compilation
-  alias Distillery.Releases.Release
-  import Distillery.Releases.Shell, only: [debug: 1, info: 1]
+
+  # Helper functions to replace Distillery.Releases.Shell to avoid circular dependency
+  defp info(msg), do: Mix.shell().info(msg)
+  defp debug(msg), do: if(System.get_env("DEBUG"), do: Mix.shell().info(msg))
 
 
   def before_assembly(_, _), do: nil
@@ -26,11 +28,14 @@ defmodule Releases.Plugin.LinkConfig do
 
   def before_package(_, _), do: nil
 
-  def after_package(%Release{version: version, profile: profile, name: name}, _) do
+  def after_package(release, _) do
+    version = Map.get(release, :version)
+    profile = Map.get(release, :profile)
+    name = Map.get(release, :name)
     # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
     # which resolves the links using the `:dereference` option when creating the tar using the
     # `:erl_tar` module.
-    output_dir = profile.output_dir
+    output_dir = if profile, do: Map.get(profile, :output_dir)
     tmp_dir = "_edeliver_release_patch"
     tmp_path = Path.join [output_dir, "releases", version, tmp_dir]
     files_to_link = [

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -14,13 +14,28 @@ defmodule Releases.Plugin.ModifyRelup do
   """
 
   # Manual behavior implementation to avoid circular dependency during compilation
-  alias Distillery.Releases.Release
   alias Edeliver.Relup.Instructions
-  import Distillery.Releases.Shell, only: [debug: 1, info: 1]
+
+  # Helper functions to replace Distillery.Releases.Shell to avoid circular dependency
+  defp info(msg), do: Mix.shell().info(msg)
+  defp debug(msg), do: if(System.get_env("DEBUG"), do: Mix.shell().info(msg))
 
   def before_assembly(_, _), do: nil
 
-  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Distillery.Releases.Profile{output_dir: output_dir}}, _) do
+  def after_assembly(release, _) do
+    is_upgrade = Map.get(release, :is_upgrade)
+    version = Map.get(release, :version)
+    name = Map.get(release, :name)
+    profile = Map.get(release, :profile)
+    output_dir = if profile, do: Map.get(profile, :output_dir)
+
+    if is_upgrade do
+      do_after_assembly(release, version, name, output_dir)
+    end
+    nil
+  end
+
+  defp do_after_assembly(release, version, name, output_dir) do
     case System.get_env "SKIP_RELUP_MODIFICATIONS" do
       "true" -> nil
       _ ->
@@ -62,7 +77,6 @@ defmodule Releases.Plugin.ModifyRelup do
     end
     nil
   end
-  def after_assembly(_, _), do: nil
 
   def before_package(_, _), do: nil
 
@@ -84,7 +98,7 @@ defmodule Releases.Plugin.ModifyRelup do
     end
   end
 
-  defp get_relup_modification_module(release = %Release{}) do
+  defp get_relup_modification_module(release) do
     case System.get_env "RELUP_MODIFICATION_MODULE" do
       module = <<_,_::binary>> ->
         module = String.to_atom(module)

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -12,8 +12,11 @@ defmodule Releases.Plugin.ModifyRelup do
     end
     ```
   """
-  use Distillery.Releases.Plugin
+
+  # Manual behavior implementation to avoid circular dependency during compilation
+  alias Distillery.Releases.Release
   alias Edeliver.Relup.Instructions
+  import Distillery.Releases.Shell, only: [debug: 1, info: 1]
 
   def before_assembly(_, _), do: nil
 

--- a/libexec/core
+++ b/libexec/core
@@ -298,21 +298,9 @@ __remote() {
 
   __log "${_hosts} : $_remote_job"
 
-  if [ -t 0 ]; then 
-    local _in_a_pipe="false"
-  else 
-    local _in_a_pipe="true"
-    local _piped_data="$(</dev/stdin)"
-  fi
-
   for _host in $_hosts
   do
-    if [ "$_in_a_pipe" = "true" ]; then
-      echo -n "$_piped_data" | ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "$_remote_job $SILENCE" &
-    else
-      ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "$_remote_job $SILENCE" &
-    fi
-
+    ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "$_remote_job $SILENCE" &
     background_jobs_pids+=("$!")
     local _background_job="ssh -o ConnectTimeout=$SSH_TIMEOUT $_host $_remote_job $SILENCE"
     background_jobs+=("ssh -o ConnectTimeout=$SSH_TIMEOUT $_host $_error_info_for_remote_job $SILENCE")

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -165,6 +165,7 @@ erlang_get_and_update_deps() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
+    [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
     if [ \"$BUILD_CMD\" = \"rebar3\" ]; then
       echo \"using rebar3 to fetch and update deps\"
       which $REBAR3_CMD || {
@@ -219,6 +220,7 @@ erlang_clean_compile() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
+    [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
     if [ \"$BUILD_CMD\" = \"rebar3\" ]; then
       echo \"using rebar3 to compile files\"
       [[ \"$SKIP_MIX_CLEAN\" != \"true\" ]] && $REBAR3_CMD clean || :
@@ -290,6 +292,7 @@ erlang_generate_release() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
+    [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
     if [ \"$RELEASE_CMD\" = \"rebar3\" ]; then
       echo \"using rebar3 to generate release\"
       REBAR_PROFILE=\"$REBAR_PROFILE\" $REBAR3_CMD $RELEASE_CMD_OPTIONS release -n $APP
@@ -330,6 +333,7 @@ relx_generate_relup() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
+    [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
     $RELX_CMD relup
   "
 
@@ -347,6 +351,7 @@ erlang_archive_release() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
+    [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
     if [ \"$RELEASE_CMD\" = \"rebar\" ] || [ \"$RELEASE_CMD\" = \"rebar3\" ]; then
       tar -zcpf $(dirname $RELEASE_DIR)/${APP}_${RELEASE_VERSION}.tar.gz -C $(dirname $RELEASE_DIR) ${APP}
     elif [ \"$RELEASE_CMD\" = \"mix\" ]; then
@@ -1463,18 +1468,20 @@ __detect_remote_release_dir() {
   if ! [ -z "$RELEASE_DIR" ]; then
     return
   else
+    local _app_dir="$DELIVER_TO"
+    [ -n "$APP_SUBDIR" ] && _app_dir="${DELIVER_TO}/${APP_SUBDIR}"
     if [ "$RELEASE_CMD" = "relx" ]; then
       local _relx_release_dir_exists
       _relx_release_dir_exists=($(__sync_remote "
         [ -f $PROFILE ] && source $PROFILE
         set -e
-        cd $DELIVER_TO $SILENCE
+        cd $_app_dir $SILENCE
         [[ -d ./_rel ]] && echo true || echo false
       ")) || error "Failed to detect generated release\n"
       if [ "$_relx_release_dir_exists" = "true" ]; then
-        RELEASE_DIR=${DELIVER_TO%%/}/_rel
+        RELEASE_DIR=${_app_dir%%/}/_rel
       else
-        error_message "Failed to detect generated release at\n$APP_USER@$HOSTS:$DELIVER_TO/_rel\n"
+        error_message "Failed to detect generated release at\n$APP_USER@$HOSTS:$_app_dir/_rel\n"
         exit 1
       fi
     else # built with rebar, mix or distillery
@@ -1488,6 +1495,7 @@ __detect_remote_release_dir() {
         [ -f $PROFILE ] && source $PROFILE
         set -e
         cd $DELIVER_TO $SILENCE
+        [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
         if [ \"$RELEASE_CMD\" = \"rebar3\" ] || [[ \"$RELEASE_CMD\" = \"mix\" && \"$USING_DISTILLERY\" = \"false\" ]]; then
           cd _build
         fi

--- a/mix.exs
+++ b/mix.exs
@@ -29,9 +29,9 @@ defmodule Edeliver.Mixfile do
     [
       {:distillery,
        git: "https://github.com/altenwald/distillery.git",
-       override: true,
        commit: "7c749b0",
-       runtime: false},
+       optional: true,
+       warn_missing: false},
       {:meck, "~> 0.8.13", only: :test},
       {:ex_doc, ">= 0.28.4", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Edeliver.Mixfile do
   defp deps do
     [
       {:distillery, git: "https://github.com/altenwald/distillery.git", commit: "7c749b0"},
+      {:artificery, github: "storestartup/artificery", override: true},
       {:meck, "~> 0.8.13", only: :test},
       {:ex_doc, ">= 0.28.4", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,11 @@ defmodule Edeliver.Mixfile do
 
   defp deps do
     [
-      {:distillery, "~> 2.1.0", optional: true, warn_missing: false},
+      {:distillery,
+       git: "https://github.com/altenwald/distillery.git",
+       override: true,
+       commit: "7c749b0",
+       runtime: false},
       {:meck, "~> 0.8.13", only: :test},
       {:ex_doc, ">= 0.28.4", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -27,11 +27,7 @@ defmodule Edeliver.Mixfile do
 
   defp deps do
     [
-      {:distillery,
-       git: "https://github.com/altenwald/distillery.git",
-       commit: "7c749b0",
-       optional: true,
-       warn_missing: false},
+      {:distillery, git: "https://github.com/altenwald/distillery.git", commit: "7c749b0"},
       {:meck, "~> 0.8.13", only: :test},
       {:ex_doc, ">= 0.28.4", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "artificery": {:hex, :artificery, "0.4.3", "0bc4260f988dcb9dda4b23f9fc3c6c8b99a6220a331534fdf5bf2fd0d4333b02", [:mix], [], "hexpm", "12e95333a30e20884e937abdbefa3e7f5e05609c2ba8cf37b33f000b9ffc0504"},
+  "artificery": {:git, "https://github.com/storestartup/artificery.git", "91180595a90bc9e236df17fe72d8993379302902", []},
   "distillery": {:git, "https://github.com/altenwald/distillery.git", "7c749b0e2f2ad9222f015e873236dc7f57ebd8f8", []},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.25", "2024618731c55ebfcc5439d756852ec4e85978a39d0d58593763924d9a15916f", [:mix], [], "hexpm", "56749c5e1c59447f7b7a23ddb235e4b3defe276afc220a6227237f3efe83f51e"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm", "514586f4312ef3709a3ccbd8e55f69455add235c1729656687bb781d10d0afdb"},
-  "distillery": {:hex, :distillery, "2.1.1", "f9332afc2eec8a1a2b86f22429e068ef35f84a93ea1718265e740d90dd367814", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm", "bbc7008b0161a6f130d8d903b5b3232351fccc9c31a991f8fcbf2a12ace22995"},
+  "artificery": {:hex, :artificery, "0.4.3", "0bc4260f988dcb9dda4b23f9fc3c6c8b99a6220a331534fdf5bf2fd0d4333b02", [:mix], [], "hexpm", "12e95333a30e20884e937abdbefa3e7f5e05609c2ba8cf37b33f000b9ffc0504"},
+  "distillery": {:git, "https://github.com/altenwald/distillery.git", "7c749b0e2f2ad9222f015e873236dc7f57ebd8f8", []},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.25", "2024618731c55ebfcc5439d756852ec4e85978a39d0d58593763924d9a15916f", [:mix], [], "hexpm", "56749c5e1c59447f7b7a23ddb235e4b3defe276afc220a6227237f3efe83f51e"},
   "ex_doc": {:hex, :ex_doc, "0.28.4", "001a0ea6beac2f810f1abc3dbf4b123e9593eaa5f00dd13ded024eae7c523298", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "bf85d003dd34911d89c8ddb8bda1a958af3471a274a4c2150a9c01c78ac3f8ed"},

--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -138,6 +138,7 @@ run() {
     local _version_that_will_be_built=$(__remote "
       [ -f $PROFILE ] && source $PROFILE
       cd $BUILD_AT $SILENCE
+      [ -n \"$APP_SUBDIR\" ] && cd \"$APP_SUBDIR\"
       MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD $_version_command
     ")
     [[ -n "$WITH" ]] && local _old_version="$WITH" || local _old_version="$OLD_RELEASE_VERSION"

--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -151,7 +151,9 @@ run() {
     # when generating upgrades with `mix release` (exrm) the old
     # release must be uploaded before generating the release.
     # `erlang_generate_release` generates the upgrade then automatically
-    RELEASE_DIR="${RELEASE_DIR:-"${DELIVER_TO}/_build/${TARGET_MIX_ENV}/rel/${APP}"}"
+    local _app_dir="${DELIVER_TO}"
+    [ -n "$APP_SUBDIR" ] && _app_dir="${DELIVER_TO}/${APP_SUBDIR}"
+    RELEASE_DIR="${RELEASE_DIR:-"${_app_dir}/_build/${TARGET_MIX_ENV}/rel/${APP}"}"
     local _release_destination_path="$(dirname $RELEASE_DIR)"
     [[ "$RELEASE_FILE" =~ upgrade\.tar\.gz$ ]] && _release_destination_path="${_release_destination_path%%/}/${APP}"
     upload_release_archive "$_release_destination_path" "$RELEASE_FILE" "$WITH"


### PR DESCRIPTION
 ## Summary
  - Adds support for monorepo projects by introducing the `APP_SUBDIR` configuration variable
  - Allows edeliver to navigate to application subdirectories during build and release processes
  - Updates distillery dependency to use altenwald fork for compatibility

  ## Changes
  - Added `APP_SUBDIR` configuration option to specify app location relative to repository root
  - Modified build and release scripts to change to app subdirectory when `APP_SUBDIR` is set
  - Updated documentation with monorepo configuration examples
  - Changed distillery dependency to altenwald/distillery fork (commit 7c749b0) for [>otp-26 and elixir >1.15 compatibility]

Really just putting it out there if anyone else is dealing with the same thing: using edeliver in a monorepo