### PR TITLE
Fix multi-host validation in erlang-update start-deploy flow

### DIFF
--- a/strategies/erlang-update
+++ b/strategies/erlang-update
@@ -105,7 +105,7 @@ run() {
     set_deploy_hosts
     update_hosts_app_user
     local _validate_upgrade_error_message
-    for _host in "${HOSTS_APP_USER}"
+    for _host in ${HOSTS_APP_USER}
     do
       __verbose -n "Checking updated version on host $_host"
       _installed_release_version=$(__get_installed_version_on_host $_host)


### PR DESCRIPTION
This PR fixes host validation in the update strategy when start-deploy is enabled.

In `erlang-update`, line 108, the host loop used a quoted scalar expansion, which caused the loop body to run once with the entire host list as a single value instead of iterating host-by-host.

The script builds HOSTS_APP_USER as a space-separated string. Quoting that expansion in a for-loop turns it into one item, causing incorrect behavior when many hosts were present.